### PR TITLE
Update TS% label, player vitals, and modal layout

### DIFF
--- a/DHP2_DeployDraft1/rosters/rosters.html
+++ b/DHP2_DeployDraft1/rosters/rosters.html
@@ -236,7 +236,7 @@
             <li><strong>YPRR:</strong> Yards per Route Run</li>
             <li><strong>1DRR:</strong> First Downs per Route Run</li>
             <li><strong>RR:</strong> Routes Run</li>
-            <li><strong>TS%RR:</strong> Target Share on Routes Run</li>
+            <li><strong>TS%:</strong> Target Share on Routes Run</li>
             <li><strong>YPR:</strong> Yards per Reception</li>
             <li><strong>SNP%:</strong> Snap Share</li>
             <li><strong>FUM:</strong> Fumbles Lost</li>

--- a/DHP2_DeployDraft1/scripts/app.js
+++ b/DHP2_DeployDraft1/scripts/app.js
@@ -1070,12 +1070,16 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             'SNP%': 'snp_pct'
         };
 
-        
+
         // === Label builder and no-fallback config (added) ===
+        const STAT_LABEL_OVERRIDES = {
+            ts_per_rr: 'TS%'
+        };
+
         function buildStatLabels() {
             const labels = {};
             for (const [header, key] of Object.entries(PLAYER_STAT_HEADER_MAP)) {
-                labels[key] = header;
+                labels[key] = STAT_LABEL_OVERRIDES[key] || header;
             }
             labels['fpts'] = 'FPTS'; // computed, not from sheet
             labels['ppg'] = 'PPG';   // keep if used elsewhere
@@ -2622,7 +2626,7 @@ const SEASON_META_HEADERS = {
                     'rec_yar': 'Yards After Catch',
                     'yprr': 'Yards per Route Run',
                     'first_down_rec_rate': 'First Down Reception Rate',
-                    'ts_per_rr': 'Targets per Route Run',
+                    'ts_per_rr': 'Target Share Percentage',
                     'rr': 'Routes Run',
                     'ypr': 'Yards per Reception',
                     'fum': 'Fumbles Lost',
@@ -3208,13 +3212,58 @@ const SEASON_META_HEADERS = {
         // --- Formatting Helpers ---
         function deriveRookieYear(player) {
             if (!player) return null;
-            let ry = player.metadata?.rookie_year ? Number(player.metadata.rookie_year) : 0;
-            const exp = player.years_exp;
-            const expNum = (exp === '' || exp === null || exp === undefined) ? null : Number(exp);
-            if ((!ry || ry === 0) && expNum === 0) {
-                return new Date().getFullYear();
+
+            const parseYearValue = (value) => {
+                if (value === undefined || value === null) return null;
+                const numeric = Number.parseInt(String(value).trim(), 10);
+                if (!Number.isFinite(numeric)) return null;
+                const currentYear = new Date().getFullYear();
+                if (numeric >= 1930 && numeric <= currentYear + 1) return numeric;
+                return null;
+            };
+
+            const candidateYears = [
+                player.metadata?.rookie_year,
+                player.metadata?.rookie,
+                player.rookie_year,
+                player.rookie,
+                player.metadata?.player_rookie_year,
+                player.metadata?.draft_year,
+                player.draft_year
+            ];
+
+            for (const candidate of candidateYears) {
+                const parsed = parseYearValue(candidate);
+                if (parsed) return parsed;
             }
-            return ry > 0 ? ry : null;
+
+            const experienceCandidates = [
+                player.years_exp,
+                player.metadata?.years_exp,
+                player.metadata?.exp,
+                player.metadata?.experience,
+                player.experience
+            ];
+
+            for (const candidate of experienceCandidates) {
+                if (candidate === undefined || candidate === null) continue;
+                if (typeof candidate === 'string') {
+                    const normalized = candidate.trim().toUpperCase();
+                    if (!normalized || normalized === 'NA' || normalized === 'N/A') continue;
+                    if (normalized === 'R' || normalized === 'ROOKIE') {
+                        return new Date().getFullYear();
+                    }
+                }
+
+                const numeric = Number.parseInt(candidate, 10);
+                if (!Number.isFinite(numeric)) continue;
+                const currentYear = new Date().getFullYear();
+                if (numeric <= 0) return currentYear;
+                const derivedYear = currentYear - numeric;
+                if (derivedYear >= 1930 && derivedYear <= currentYear + 1) return derivedYear;
+            }
+
+            return null;
         }
         function getPosRankColor(posRank) {
             if (!posRank || typeof posRank !== 'string') return 'var(--color-text-secondary)';
@@ -3252,7 +3301,7 @@ const SEASON_META_HEADERS = {
         }
 
         function getPlayerVitals(playerId) {
-            const fallback = { age: '—', height: '—', weight: '—' };
+            const fallback = { age: '—', height: '—', weight: '—', experience: '—', rookieYear: '—' };
             const playerData = state.players?.[playerId];
             if (!playerData) return fallback;
 
@@ -3383,10 +3432,85 @@ const SEASON_META_HEADERS = {
                 return null;
             };
 
+            const parseRookieYear = () => {
+                const candidates = collect(
+                    playerData.metadata?.rookie_year,
+                    playerData.metadata?.rookie,
+                    playerData.rookie_year,
+                    playerData.rookie,
+                    playerData.metadata?.player_rookie_year,
+                    playerData.metadata?.draft_year,
+                    playerData.draft_year
+                );
+
+                const parseYearValue = (value) => {
+                    if (value === undefined || value === null) return null;
+                    const numeric = Number.parseInt(String(value).trim(), 10);
+                    if (!Number.isFinite(numeric)) return null;
+                    const currentYear = new Date().getFullYear();
+                    if (numeric >= 1930 && numeric <= currentYear + 1) return numeric;
+                    return null;
+                };
+
+                for (const candidate of candidates) {
+                    const parsed = parseYearValue(candidate);
+                    if (parsed) return parsed;
+                }
+
+                const derived = deriveRookieYear(playerData);
+                return derived ?? null;
+            };
+
+            const parseExperience = (rookieYearValue) => {
+                const candidates = collect(
+                    playerData.years_exp,
+                    playerData.metadata?.years_exp,
+                    playerData.metadata?.exp,
+                    playerData.metadata?.experience,
+                    playerData.experience
+                );
+
+                const parseExperienceValue = (candidate) => {
+                    if (candidate === undefined || candidate === null) return null;
+                    if (typeof candidate === 'string') {
+                        const normalized = candidate.trim().toUpperCase();
+                        if (!normalized || normalized === 'NA' || normalized === 'N/A') return null;
+                        if (normalized === 'R' || normalized === 'ROOKIE') return 'R';
+                    }
+
+                    const numeric = Number.parseInt(candidate, 10);
+                    if (!Number.isFinite(numeric)) return null;
+                    if (numeric <= 0) return 'R';
+                    return String(numeric);
+                };
+
+                for (const candidate of candidates) {
+                    const parsed = parseExperienceValue(candidate);
+                    if (parsed) return parsed;
+                }
+
+                if (rookieYearValue) {
+                    const rookieYearNumber = Number.parseInt(rookieYearValue, 10);
+                    if (Number.isFinite(rookieYearNumber)) {
+                        const currentYear = new Date().getFullYear();
+                        const diff = currentYear - rookieYearNumber;
+                        if (diff <= 0) return 'R';
+                        if (diff > 0 && diff < 60) return String(diff);
+                    }
+                }
+
+                return null;
+            };
+
+            const rookieYear = parseRookieYear();
+            const experience = parseExperience(rookieYear);
+
             return {
                 age: parseAge() ?? '—',
                 height: parseHeight() ?? '—',
-                weight: parseWeight() ?? '—'
+                weight: parseWeight() ?? '—',
+                experience: experience ?? '—',
+                rookieYear: rookieYear ?? '—'
             };
         }
 
@@ -3396,6 +3520,8 @@ const SEASON_META_HEADERS = {
 
             const items = [
                 { label: 'AGE', value: vitals.age },
+                { label: 'EXP', value: vitals.experience },
+                { label: 'RY', value: vitals.rookieYear },
                 { label: 'HEIGHT', value: vitals.height },
                 { label: 'WEIGHT', value: vitals.weight }
             ];

--- a/DHP2_DeployDraft1/styles/styles.css
+++ b/DHP2_DeployDraft1/styles/styles.css
@@ -3064,6 +3064,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     
     #modal-header {
       text-align: center;
+      --modal-metrics-max-width: 720px;
     }
     
     #modal-player-name {
@@ -3074,6 +3075,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     #modal-player-vitals {
       display: flex;
       justify-content: center;
+      width: 100%;
     }
 
     .player-vitals {
@@ -3088,6 +3090,10 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
       flex-direction: column;
       align-items: center;
       gap: 0.1rem;
+    }
+
+    .player-vitals--modal .player-vitals__item {
+      flex: 1 1 110px;
     }
 
     .player-vitals__label {
@@ -3106,19 +3112,18 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     }
 
     .player-vitals--modal {
-      margin: 0 0 0.7rem;
-    border: 1px solid #ffffff10;
-    padding: 4px 7px;
-    border-radius: 8px;
-    }
-    
-    
-    .player-vitals--modal {    
-    position: relative;
-    background: rgba(0, 0, 0, 0.02);
-    backdrop-filter: blur(1px) saturate(180%);
-    border: 1px solid rgba(250, 250, 250, 0.1);
-    box-shadow: 0 8px 32px rgba(31, 38, 105, 0.1), inset 0 6px 20px rgba(255, 255, 255, 0.013);
+      margin: 0 auto 0.7rem;
+      padding: 4px 12px;
+      border-radius: 8px;
+      position: relative;
+      background: rgba(0, 0, 0, 0.02);
+      backdrop-filter: blur(1px) saturate(180%);
+      border: 1px solid rgba(250, 250, 250, 0.1);
+      box-shadow: 0 8px 32px rgba(31, 38, 105, 0.1), inset 0 6px 20px rgba(255, 255, 255, 0.013);
+      width: min(100%, var(--modal-metrics-max-width));
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 1.1rem;
     }
     .player-vitals--modal::after {    
         content: '';
@@ -3160,16 +3165,21 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     
     #modal-summary-row {
       display: flex;
-      justify-content: center;
+      flex-direction: column;
       align-items: center;
-      gap: 0.5rem;
-      margin-bottom: 0.75rem;
+      gap: 0.75rem;
+      margin: 0 auto 0.75rem;
+      width: 100%;
     }
 
     #modal-summary-chips {
-      display: flex;
-      gap: 1rem;
-      flex-wrap: nowrap;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.75rem;
+      width: min(100%, var(--modal-metrics-max-width));
+      margin: 0 auto;
+      align-items: stretch;
+      grid-auto-rows: 1fr;
     }
     
     /* · · Summary Chips · · */
@@ -3235,7 +3245,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
 
 /* · · GameLogs Summary Chips · · */
 #game-logs-modal .gamelogs-summary-chip {
-    padding: 0.25rem 0.55rem;
+    padding: 0.4rem 0.75rem;
     text-align: center;
     min-width: auto;
     position: relative;
@@ -3244,6 +3254,12 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     border: 1px solid rgba(250, 250, 250, 0.1);
     border-radius: 13px;
     box-shadow: 0 8px 32px rgba(31, 38, 105, 0.1), inset 0 6px 20px rgba(255, 255, 255, 0.013);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    height: 100%;
 }
 
 #game-logs-modal .gamelogs-summary-chip::after {
@@ -3277,6 +3293,11 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     border-bottom: 1px solid var(--color-panel-border);
     padding-bottom: 0.1rem;
     gap: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
 }
 #game-logs-modal .gamelogs-summary-chip .chip-header-value {
     font-size: 0.8rem;
@@ -3289,6 +3310,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     font-size: 0.85rem;
     color: var(--color-text-primary);
     font-weight: 400;
+    width: 100%;
 }
 #game-logs-modal .gamelogs-summary-chip .chip-separator {
     margin: 0 0.25rem;


### PR DESCRIPTION
## Summary
- rename the shared TS%RR stat label to display as TS% and update the comparison key description
- extend modal player vitals parsing to surface experience and rookie year with additional fallbacks
- realign the game log modal layout so the vitals block and summary chips share a centered width and equal-height chips

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d407fad72c832eba13508b31e7df54