### PR TITLE
Update TS label and modal vitals presentation

### DIFF
--- a/DHP2_DeployDraft1/rosters/rosters.html
+++ b/DHP2_DeployDraft1/rosters/rosters.html
@@ -236,7 +236,7 @@
             <li><strong>YPRR:</strong> Yards per Route Run</li>
             <li><strong>1DRR:</strong> First Downs per Route Run</li>
             <li><strong>RR:</strong> Routes Run</li>
-            <li><strong>TS%RR:</strong> Target Share on Routes Run</li>
+            <li><strong>TS%:</strong> Target Share on Routes Run</li>
             <li><strong>YPR:</strong> Yards per Reception</li>
             <li><strong>SNP%:</strong> Snap Share</li>
             <li><strong>FUM:</strong> Fumbles Lost</li>

--- a/DHP2_DeployDraft1/scripts/app.js
+++ b/DHP2_DeployDraft1/scripts/app.js
@@ -1062,7 +1062,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             'YAC': 'rec_yar',
             'YPR': 'ypr',
             'RR': 'rr',
-            'TS%RR': 'ts_per_rr',
+            'TS%': 'ts_per_rr',
             'YPRR': 'yprr',
             '1DRR': 'first_down_rec_rate',
             'IMP': 'imp',
@@ -3252,7 +3252,7 @@ const SEASON_META_HEADERS = {
         }
 
         function getPlayerVitals(playerId) {
-            const fallback = { age: '—', height: '—', weight: '—' };
+            const fallback = { age: '—', exp: '—', ry: '—', height: '—', weight: '—' };
             const playerData = state.players?.[playerId];
             if (!playerData) return fallback;
 
@@ -3287,6 +3287,34 @@ const SEASON_META_HEADERS = {
                             return String(age);
                         }
                     }
+                }
+
+                return null;
+            };
+
+            const parseExperience = () => {
+                const candidates = collect(
+                    playerData.years_exp,
+                    playerData.metadata?.years_exp,
+                    playerData.metadata?.player_experience
+                );
+
+                for (const candidate of candidates) {
+                    if (typeof candidate === 'number') {
+                        if (!Number.isFinite(candidate)) continue;
+                        return candidate <= 0 ? 'R' : String(candidate);
+                    }
+
+                    const str = String(candidate).trim();
+                    if (!str) continue;
+                    if (/^r(ookie)?$/i.test(str)) return 'R';
+
+                    const numeric = Number.parseInt(str, 10);
+                    if (Number.isFinite(numeric)) {
+                        return numeric <= 0 ? 'R' : String(numeric);
+                    }
+
+                    return str.toUpperCase();
                 }
 
                 return null;
@@ -3383,8 +3411,34 @@ const SEASON_META_HEADERS = {
                 return null;
             };
 
+            const parseRookieYear = () => {
+                const candidates = collect(
+                    playerData.metadata?.rookie_year,
+                    playerData.rookie_year,
+                    playerData.metadata?.player_rookie_year
+                );
+
+                for (const candidate of candidates) {
+                    const numeric = Number.parseInt(candidate, 10);
+                    if (Number.isFinite(numeric) && numeric >= 1900 && numeric <= 2100) {
+                        return String(numeric);
+                    }
+                }
+
+                if (typeof deriveRookieYear === 'function') {
+                    const derived = deriveRookieYear(playerData);
+                    if (Number.isFinite(derived)) {
+                        return String(derived);
+                    }
+                }
+
+                return null;
+            };
+
             return {
                 age: parseAge() ?? '—',
+                exp: parseExperience() ?? '—',
+                ry: parseRookieYear() ?? '—',
                 height: parseHeight() ?? '—',
                 weight: parseWeight() ?? '—'
             };
@@ -3396,6 +3450,8 @@ const SEASON_META_HEADERS = {
 
             const items = [
                 { label: 'AGE', value: vitals.age },
+                { label: 'EXP', value: vitals.exp },
+                { label: 'RY', value: vitals.ry },
                 { label: 'HEIGHT', value: vitals.height },
                 { label: 'WEIGHT', value: vitals.weight }
             ];

--- a/DHP2_DeployDraft1/styles/styles.css
+++ b/DHP2_DeployDraft1/styles/styles.css
@@ -3064,6 +3064,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     
     #modal-header {
       text-align: center;
+      --modal-metrics-max-width: clamp(20rem, 80vw, 34rem);
     }
     
     #modal-player-name {
@@ -3106,10 +3107,19 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     }
 
     .player-vitals--modal {
-      margin: 0 0 0.7rem;
-    border: 1px solid #ffffff10;
-    padding: 4px 7px;
-    border-radius: 8px;
+      margin: 0 auto 0.7rem;
+      width: min(100%, var(--modal-metrics-max-width, 34rem));
+      border: 1px solid #ffffff10;
+      padding: 6px 12px;
+      border-radius: 8px;
+      justify-content: space-between;
+      gap: clamp(0.35rem, 1.5vw, 1rem);
+      align-items: stretch;
+    }
+
+    .player-vitals--modal .player-vitals__item {
+      flex: 1 1 0;
+      min-width: 0;
     }
     
     
@@ -3143,10 +3153,18 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
 
     .player-vitals--compare {
       margin-top: 0.18rem;
-    gap: 1.3rem;
-    border-radius: 8px;
-    border: 1px solid #fff2;
-    padding: 3px 7px;
+      gap: 1rem;
+      border-radius: 8px;
+      border: 1px solid #fff2;
+      padding: 3px 7px;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: stretch;
+    }
+
+    .player-vitals--compare .player-vitals__item {
+      flex: 1 1 calc(50% - 0.5rem);
+      min-width: 4.5rem;
     }
 
     .player-vitals--compare .player-vitals__label {
@@ -3162,14 +3180,18 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
       display: flex;
       justify-content: center;
       align-items: center;
-      gap: 0.5rem;
       margin-bottom: 0.75rem;
+      width: 100%;
     }
 
     #modal-summary-chips {
-      display: flex;
-      gap: 1rem;
-      flex-wrap: nowrap;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+      gap: 0.9rem;
+      width: min(100%, var(--modal-metrics-max-width, 34rem));
+      margin: 0 auto;
+      align-items: stretch;
+      justify-items: stretch;
     }
     
     /* · · Summary Chips · · */
@@ -3235,15 +3257,19 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
 
 /* · · GameLogs Summary Chips · · */
 #game-logs-modal .gamelogs-summary-chip {
-    padding: 0.25rem 0.55rem;
+    padding: 0.4rem 0.75rem;
     text-align: center;
-    min-width: auto;
+    min-width: 0;
     position: relative;
     background: rgba(0, 0, 0, 0.02);
     backdrop-filter: blur(1px) saturate(180%);
     border: 1px solid rgba(250, 250, 250, 0.1);
     border-radius: 13px;
     box-shadow: 0 8px 32px rgba(31, 38, 105, 0.1), inset 0 6px 20px rgba(255, 255, 255, 0.013);
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 0.3rem;
 }
 
 #game-logs-modal .gamelogs-summary-chip::after {
@@ -3276,7 +3302,10 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     text-transform: uppercase;
     border-bottom: 1px solid var(--color-panel-border);
     padding-bottom: 0.1rem;
-    gap: 0.5rem;
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 0.35rem;
 }
 #game-logs-modal .gamelogs-summary-chip .chip-header-value {
     font-size: 0.8rem;
@@ -3285,7 +3314,7 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 0.00rem;
+    gap: 0.25rem;
     font-size: 0.85rem;
     color: var(--color-text-primary);
     font-weight: 400;


### PR DESCRIPTION
## Summary
- rename the TS%RR stat label to TS% everywhere it appears in the UI
- surface EXP and RY in the player vitals data and render them alongside the existing vitals
- align the player vitals strip with the summary chip grid and make the chips share a balanced width

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d407fad72c832eba13508b31e7df54