### PR TITLE
Revamp analyzer UI and add sleeper-driven metrics

### DIFF
--- a/DHP2_DeployDraft1.2/analyzer/analyzer.html
+++ b/DHP2_DeployDraft1.2/analyzer/analyzer.html
@@ -1,998 +1,1125 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sleeper League KTC Infographic</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
-    <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
-    <style>
-        :root {
-            --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
-            --color-bg: #0D0E1B;
-            --color-panel-border: rgba(128, 138, 189, 0.2);
-            --color-text-primary: #EAEBF0;
-            --color-text-secondary: #9096C0;
-            --color-accent-primary: #766DFF;
-            --color-accent-primary-glow: rgba(118, 109, 255, 0.5);
-        }
-
-        body {
-            font-family: var(--font-sans);
-            background-color: var(--color-bg);
-            color: var(--color-text-primary);
-            overflow-x: hidden;
-        }
-
-        #starfield {
-            position: fixed; inset: 0; z-index: -10; pointer-events: none;
-            background: radial-gradient(ellipse at 50% 100%, #1B2735 0%, #090A0F 100%);
-        }
-
-        #stars1, #stars2, #stars3 {
-            position: absolute; left: 0; top: 0;
-            background: transparent;
-            animation: animStar linear infinite;
-        }
-
-        #stars1 { width: 1px; height: 1px; box-shadow: 1528px 425px #FFF, 1965px 1848px #FFF, 466px 588px #FFF, 1441px 1361px #FFF, 395px 1296px #FFF, 1603px 1631px #FFF, 1403px 1363px #FFF, 1010px 54px #FFF, 904px 1539px #FFF, 929px 1400px #FFF, 1370px 1286px #FFF, 612px 1109px #FFF, 1899px 1371px #FFF, 215px 873px #FFF, 1997px 882px #FFF, 283px 759px #FFF, 1675px 1005px #FFF, 145px 1973px #FFF, 1974px 1948px #FFF, 128px 1115px #FFF, 1863px 1335px #FFF, 1540px 938px #FFF, 1739px 491px #FFF, 1898px 1397px #FFF, 706px 1264px #FFF, 1505px 1162px #FFF, 200px 1889px #FFF, 1044px 1230px #FFF, 315px 1227px #FFF, 625px 217px #FFF, 1813px 1135px #FFF, 287px 791px #FFF, 1131px 816px #FFF, 845px 87px #FFF, 272px 94px #FFF, 1341px 1194px #FFF, 1547px 893px #FFF, 1460px 1971px #FFF, 655px 1052px #FFF, 1178px 815px #FFF, 1643px 1785px #FFF, 1172px 277px #FFF, 1486px 280px #FFF, 134px 1224px #FFF, 338px 213px #FFF, 814px 1844px #FFF, 1207px 806px #FFF, 14px 526px #FFF, 957px 455px #7300ff, 518px 864px #7300ff, 321px 438px #7300ff, 1226px 1328px #FFF, 784px 1010px #FF0266, 1052px 1568px #FF0266, 350px 478px #FF0266; animation-duration: 450s; }
-        #stars2 { width: 2px; height: 2px; box-shadow: 444px 26px #FFF, 644px 550px #FFF, 428px 426px #FFF, 12px 1913px #FFF, 680px 225px #FFF, 1346px 474px #FFF, 6px 1693px #FFF, 1555px 996px #FFF, 579px 1620px #FFF, 364px 1911px #FFF, 282px 1788px #FFF, 280px 337px #FFF, 1880px 1547px #FF0266, 1531px 1567px #FF0266, 193px 1099px #FF0266, 1540px 17px #FF0266, 1774px 292px #FF0266, 183px 775px #FF0266, 214px 107px #FFF, 695px 88px #FFF, 490px 1209px #FFF, 1374px 560px #FFF, 752px 1759px #FFF, 1985px 866px #FFF, 609px 310px #FFF, 86px 1036px #FFF, 638px 191px #FFF, 1635px 626px #FFF, 78px 998px #FFF, 1189px 1345px #FFF, 48px 1383px #FFF, 1981px 345px #FFF, 1993px 1838px #FFF, 717px 1540px #FFF, 287px 673px #FFF, 1821px 1665px #FFF, 686px 600px #FFF, 572px 777px #FFF, 932px 537px #FFF, 1808px 1538px #FFF, 1563px 305px #FFF, 1771px 1974px #FFF, 393px 1768px #FFF, 368px 1426px #FFF, 434px 779px #FFF, 566px 1370px #FFF, 261px 791px #FFF, 141px 434px #1ACDD1; animation-duration: 400s; }
-        #stars3 { width: 3px; height: 3px; box-shadow: 1208px 1620px #FF0070, 576px 1883px #FFF, 1810px 913px #FFF, 87px 1117px #FFF, 1076px 1851px #FFF, 859px 264px #FFF, 1469px 1346px #FFF, 1651px 1493px #FFF, 767px 822px #FFF, 359px 967px #FFF, 1009px 808px #FF0070, 100px 1656px #7300ff, 1365px 1511px #7300ff, 429px 1279px #7300ff, 1381px 1850px #E86439, 1896px 1999px #E86439, 236px 718px #7300ff, 39px 1731px #7300ff, 562px 1084px #7300ff, 1067px 1431px #FF0266, 1362px 1575px #FF0266, 953px 1860px #FF0266, 1498px 499px #FF0266, 1055px 885px #FFF, 1824px 1334px #FFF, 519px 1319px #FFF, 1716px 1538px #FFF, 1305px 524px #FFF, 808px 1972px #FFF, 426px 649px #FFF, 882px 1530px #FFF, 623px 557px #FFF, 129px 1750px #FF0070; animation-duration: 350s; }
-        
-        @keyframes animStar { from { transform: translateY(0px); } to { transform: translateY(-2000px); } }
-
-        .glass-panel {
-            background-color: rgba(13, 14, 35, 0.21);
-            background-image: linear-gradient(rgba(255,255,255, 0.03), rgba(255,255,255, 0.03));
-            backdrop-filter: blur(6px) saturate(120%) brightness(120%);
-            border: 1px solid rgba(128, 138, 189, 0.2);
-            border-radius: 10px;
-            box-shadow: inset 0 0 0 1px rgba(255,255,255, 0.05), 
-                        inset 0 0 0 2px rgba(200,200,200, 0.025), 
-                        0 10px 26px rgba(0,0,0, .22);
-        }
-        
-        h1, h2, h3 {
-            font-family: var(--font-sans);
-            color: var(--color-text-primary);
-            text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
-        }
-        h1 { font-weight: 700; }
-        h2 { font-weight: 500; }
-        h3 { font-weight: 500; }
-        
-        .chart-container {
-            position: relative;
-            height: 450px;
-            width: 100%;
-        }
-
-        .power-grid-item h3 {
-            font-size: 1rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: .8px;
-            color: var(--color-text-primary);
-            text-align: center;
-            padding: 0.2rem 0;
-            margin-bottom: 0.5rem;
-            position: relative;
-            border: 1px solid var(--color-panel-border);
-            border-radius: 5px;
-            backdrop-filter: saturate(114%) blur(1px);
-            overflow: hidden;
-        }
-
-        .power-grid-item h3::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            border-radius: inherit;
-            pointer-events: none;
-            background-color: rgba(20, 28, 58, 0.15);
-            background-image: linear-gradient(rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 35%);
-        }
-
-
-        /* Fix for browser autofill styles */
-        input:-webkit-autofill,
-        input:-webkit-autofill:hover,
-        input:-webkit-autofill:focus,
-        input:-webkit-autofill:active {
-            -webkit-box-shadow: 0 0 0 30px #0D0E1B inset !important; /* Match body bg */
-            -webkit-text-fill-color: #c4c8ea !important;
-            transition: background-color 5000s ease-in-out 0s;
-            caret-color: #c4c8ea;
-        }
-
-        #usernameInput, #leagueSelect {
-            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
-            border: 1px solid var(--color-panel-border);
-            border-radius: 8px;
-            backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-            color: #c4c8ea;
-            transition: all 0.2s ease;
-        }
-
-        #usernameInput:focus, #leagueSelect:focus {
-            outline: none;
-            border-color: var(--color-accent-primary);
-            box-shadow: 0 0 8px var(--color-accent-primary-glow);
-        }
-
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>League Analyzer • Dynasty Hub</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet" />
+  <link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+  <meta name="theme-color" content="#0D0E1B" />
+  <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+  <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.plot.ly/plotly-2.32.0.min.js"></script>
 </head>
 <body data-page="analyzer" class="p-2 sm:p-4">
-    <!-- Replaced Background: Starfield -->
-    <div aria-hidden="true" id="starfield">
-        <div id="stars1"></div>
-        <div id="stars2"></div>
-        <div id="stars3"></div>
+  <div aria-hidden="true" id="starfield">
+    <div id="stars"></div>
+    <div id="stars1"></div>
+    <div id="stars2"></div>
+    <div id="stars3"></div>
+  </div>
+  <div id="noise-overlay"></div>
+  <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+      <header class="app-header glass-panel">
+        <div class="header-row">
+          <div class="menu-container">
+            <button id="menu-button" class="menu-button" aria-label="Toggle navigation">
+              <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+              </svg>
+            </button>
+            <div id="dropdown-menu" class="dropdown-menu hidden">
+              <a href="../index.html">
+                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                <span>Home</span>
+              </a>
+              <a href="#" id="menu-rosters">
+                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                <span>Rosters</span>
+              </a>
+              <a href="#" id="menu-ownership">
+                <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                <span>Ownership</span>
+              </a>
+              <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+              </a>
+              <a href="#" id="menu-analyzer" class="active">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+              </a>
+            </div>
+          </div>
+          <div class="username-area">
+            <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle" />
+          </div>
+          <div class="custom-select-wrapper">
+            <select id="leagueSelect" disabled aria-label="Sleeper league selector">
+              <option>Select a league...</option>
+            </select>
+          </div>
+        </div>
+      </header>
     </div>
-    <div id="noise-overlay"></div>
-    <div class="relative z-10 content-wrapper">
-        <div id="header-container">
-            <header class="app-header glass-panel">
-                <div class="header-row">
-                    <div class="menu-container">
-                        <button id="menu-button" class="menu-button">
-                            <svg viewBox="0 0 100 80" width="20" height="20">
-                                <rect width="100" height="15"></rect>
-                                <rect y="30" width="100" height="15"></rect>
-                                <rect y="60" width="100" height="15"></rect>
-                            </svg>
-                        </button>
-                        <div id="dropdown-menu" class="dropdown-menu hidden">
-                            <a href="../">
-                                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-                                <span>Home</span>
-                            </a>
-                            <a href="#" id="menu-rosters">
-                                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-                                <span>Rosters</span>
-                            </a>
-                            <a href="#" id="menu-ownership">
-                                <i class="fa-solid fa-percent" aria-hidden="true"></i>
-                                <span>Ownership</span>
-                            </a>
-                            <a href="#" id="menu-research">
-                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                                <span>Research</span>
-                            </a>
-                            <a href="#" id="menu-analyzer">
-                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                                <span>League Analyzer</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="username-area">
-                        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-                    </div>
-                    <div class="custom-select-wrapper">
-                        <select id="leagueSelect" disabled>
-                            <option>Select a league...</option>
-                        </select>
-                    </div>
+
+    <main class="container mx-auto" id="content">
+      <div class="max-w-7xl mx-auto space-y-6 md:space-y-8">
+        <header class="analyzer-hero">
+          <div class="analyzer-hero-meta">
+            <div class="analyzer-pill">Dynasty Hub Intelligence</div>
+            <h1>League Analyzer</h1>
+            <p>Compare roster value, production, and positional balance across your Sleeper league.</p>
+          </div>
+        </header>
+
+        <section id="summaryStats" class="hidden analyzer-summary-grid" aria-label="Team summary metrics"></section>
+
+        <div id="loading" class="hidden analyzer-loading" role="status" aria-live="polite">
+          <p>Analyzing cosmic data streams...</p>
+        </div>
+
+        <section id="infographicContent" class="hidden space-y-6 md:space-y-8">
+          <div class="grid grid-cols-1 xl:grid-cols-2 gap-4 md:gap-6">
+            <article class="glass-panel analyzer-panel" id="starters-panel">
+              <header class="panel-header">
+                <div>
+                  <h2>Starting Lineup Value</h2>
+                  <p>Stacked KTC value or combined fantasy PPG by required starter slots.</p>
                 </div>
+                <div class="panel-toggle" role="group" aria-label="Starter metric mode">
+                  <button type="button" data-mode="ktc" class="active">KTC Value</button>
+                  <button type="button" data-mode="ppg">Starter PPG</button>
+                </div>
+              </header>
+              <div class="chart-shell">
+                <canvas id="startersValueChart" aria-label="Starting lineup comparison chart"></canvas>
+              </div>
+            </article>
+
+            <article class="glass-panel analyzer-panel" id="overall-panel">
+              <header class="panel-header">
+                <div>
+                  <h2>Overall Team Equity</h2>
+                  <p>Total KTC value distribution across full rosters.</p>
+                </div>
+              </header>
+              <div class="chart-shell">
+                <canvas id="overallValueChart" aria-label="Overall roster value chart"></canvas>
+              </div>
+            </article>
+          </div>
+
+          <section class="glass-panel analyzer-panel" id="radar-panel">
+            <header class="panel-header">
+              <div>
+                <h2>Positional Strength Radar</h2>
+                <p>Best-fit starters versus league averages, scaled to your most valuable options.</p>
+              </div>
             </header>
-        </div>
-        <main class="container mx-auto" id="content">
-            <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
-                <!-- Page Header -->
-                <header class="text-center space-y-2">
-                    <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
-                    <p class="text-md text-gray-400">KTC Team Value Analysis</p>
-                </header>
+            <div id="radarChartContainer" class="radar-shell" role="img" aria-label="Positional strength radar chart"></div>
+          </section>
 
-                <!-- Summary Stats -->
-                <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
-            <!-- Summary boxes injected here -->
+          <section class="glass-panel analyzer-panel" id="standings-panel">
+            <header class="panel-header">
+              <div>
+                <h2>League Standings</h2>
+                <p>Record, points for, and points against from Sleeper league settings.</p>
+              </div>
+            </header>
+            <div class="table-shell">
+              <table id="standingsTable">
+                <thead>
+                  <tr>
+                    <th scope="col">Team</th>
+                    <th scope="col">Record</th>
+                    <th scope="col">PF</th>
+                    <th scope="col">PA</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="glass-panel analyzer-panel" id="leaders-panel">
+            <header class="panel-header">
+              <div>
+                <h2>Positional Leaders</h2>
+                <p>Top 10 fantasy point scorers at each position and their current managers.</p>
+              </div>
+              <div class="panel-toggle leaders-toggle" role="tablist" aria-label="Position leaderboard filter">
+                <button type="button" data-position="QB" class="active" role="tab" aria-selected="true">QB</button>
+                <button type="button" data-position="RB" role="tab" aria-selected="false">RB</button>
+                <button type="button" data-position="WR" role="tab" aria-selected="false">WR</button>
+                <button type="button" data-position="TE" role="tab" aria-selected="false">TE</button>
+              </div>
+            </header>
+            <div class="table-shell">
+              <table id="leadersTable">
+                <thead>
+                  <tr>
+                    <th scope="col">Rank</th>
+                    <th scope="col">Player</th>
+                    <th scope="col">Team</th>
+                    <th scope="col">FPTS</th>
+                    <th scope="col">PPG</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </section>
         </section>
-
-        <!-- Loading Indicator -->
-        <div id="loading" class="hidden text-center py-8">
-            <p class="text-2xl animate-pulse">Analyzing cosmic data streams...</p>
-        </div>
-
-        <!-- Main Content -->
-        <section id="infographicContent" class="hidden space-y-6">
-            <!-- Top Level Charts -->
-            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Starting Lineup Value</h2>
-                    <div class="chart-container">
-                        <canvas id="startersValueChart"></canvas>
-                    </div>
-                </div>
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Overall Team Value</h2>
-                    <div class="chart-container">
-                        <canvas id="overallValueChart"></canvas>
-                    </div>
-                </div>
-            </section>
-            
-            <!-- Radar Chart -->
-            <section class="glass-panel p-2">
-                <h2 class="text-2xl text-center mb-4">Positional Strength</h2>
-                <div class="chart-container">
-                    <canvas id="radarChart"></canvas>
-                </div>
-            </section>
-
-            <!-- Detailed Starter Rankings -->
-            <section class="glass-panel p-6">
-                <h2 class="text-2xl text-center mb-6">Starting Position Power Grid</h2>
-                <div id="starterRankingsGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-                    <!-- Grid items will be injected here by JavaScript -->
-                </div>
-            </section>
-        </section>
-    </div>
-        </main>
-    </div>
-
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const params = new URLSearchParams(window.location.search);
-            const username = params.get('username');
-            const leagueId = params.get('leagueId');
-
-            // --- DOM Elements ---
-            const usernameInput = document.getElementById('usernameInput');
-            const leagueSelect = document.getElementById('leagueSelect');
-            const loadingIndicator = document.getElementById('loading');
-            const infographicContent = document.getElementById('infographicContent');
-            const starterRankingsGrid = document.getElementById('starterRankingsGrid');
-            const summaryStats = document.getElementById('summaryStats');
-
-
-            // --- Chart instances ---
-            let overallChart, startersChart, radarChart;
-
-            // --- State ---
-            let state = {
-                userId: null,
-                leagues: [],
-                players: {},
-                ktcOneQb: {},
-                ktcSflx: {},
-                currentLeagueId: null,
-                isSuperflex: false,
-                cache: {}
-            };
-
-            const POS_COLORS = {
-                QB: 'rgba(255, 58, 117, 0.8)',
-                RB: 'rgba(0, 235, 199, 0.8)',
-                WR: 'rgba(88, 167, 255, 0.8)',
-                TE: 'rgba(180, 105, 255, 0.8)',
-                FLEX: 'rgba(255, 127, 80, 0.8)', // Coral
-                SUPER_FLEX: 'rgba(220, 220, 220, 0.8)', // Silver
-                Picks: 'rgba(255, 199, 0, 0.8)'
-            };
-
-
-            // --- Event Listeners ---
-            usernameInput.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') {
-                    handleFetchData();
-                }
-            });
-            leagueSelect.addEventListener('change', () => {
-                if (leagueSelect.value) {
-                    analyzeLeague(leagueSelect.value);
-                }
-            });
-
-            if (username) {
-                usernameInput.value = username;
-                handleFetchData();
-            }
-
-            async function handleFetchData() {
-                const username = usernameInput.value.trim();
-                if (!username) {
-                    alert('Please enter a Sleeper username.');
-                    return;
-                }
-
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                summaryStats.classList.add('hidden');
-
-                try {
-                    // Fetch all initial data concurrently
-                    await Promise.all([
-                        fetchSleeperPlayers(),
-                        fetchKTCData()
-                    ]);
-                    
-                    await fetchUserAndLeagues(username);
-
-                    if (state.leagues.length > 0) {
-                        if (leagueId) {
-                            const leagueExists = state.leagues.some(l => l.league_id === leagueId);
-                            if (leagueExists) {
-                                leagueSelect.value = leagueId;
-                                await analyzeLeague(leagueId);
-                            } else {
-                                alert('The specified league was not found for this user.');
-                                setLoading(false);
-                            }
-                        } else {
-                            // Auto-select and analyze the first league
-                            leagueSelect.selectedIndex = 1;
-                            await analyzeLeague(state.leagues[0].league_id);
-                        }
-                    }
-                } catch (error) {
-                    console.error('Error fetching data:', error);
-                    alert(`An error occurred: ${error.message}`);
-                } finally {
-                    setLoading(false);
-                }
-            }
-
-            // --- Data Fetching ---
-            async function fetchWithCache(url) {
-                if (state.cache[url]) return state.cache[url];
-                const response = await fetch(url);
-                if (!response.ok) throw new Error(`API request failed: ${response.statusText}`);
-                const data = await response.json();
-                state.cache[url] = data;
-                return data;
-            }
-
-            async function fetchSleeperPlayers() {
-                if (Object.keys(state.players).length > 0) return;
-                state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
-            }
-
-            async function fetchKTCData() {
-                if (Object.keys(state.ktcOneQb).length > 0) return;
-                const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
-                try {
-                    const [oneQbCsv, sflxCsv] = await Promise.all([
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch 1QB KTC data: ' + res.statusText);
-                            return res.text();
-                        }),
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch SFLX KTC data: ' + res.statusText);
-                            return res.text();
-                        })
-                    ]);
-                    state.ktcOneQb = parseSheetData(oneQbCsv);
-                    state.ktcSflx = parseSheetData(sflxCsv);
-                } catch (error) {
-                     console.error("KTC Fetch Error:", error);
-                     throw new Error("Could not retrieve KTC valuation data. The proxy service may be down. Please try again later.");
-                }
-            }
-            
-            function parseSheetData(csvText) {
-                const dataMap = {};
-                const lines = csvText.split(/\r?\n/).filter(line => line.trim().length > 0);
-                if (lines.length === 0) return dataMap;
-
-                const parseLine = (line) => {
-                    const result = [];
-                    let current = '';
-                    let inQuotes = false;
-                    const sanitized = line.replace(/\r$/, '');
-
-                    for (let i = 0; i < sanitized.length; i++) {
-                        const char = sanitized[i];
-                        if (inQuotes) {
-                            if (char === '"') {
-                                if (sanitized[i + 1] === '"') {
-                                    current += '"';
-                                    i++;
-                                } else {
-                                    inQuotes = false;
-                                }
-                            } else {
-                                current += char;
-                            }
-                        } else if (char === '"') {
-                            inQuotes = true;
-                        } else if (char === ',') {
-                            result.push(current.trim());
-                            current = '';
-                        } else {
-                            current += char;
-                        }
-                    }
-                    result.push(current.trim());
-                    return result;
-                };
-
-                const normalize = (header) => header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
-                const headers = parseLine(lines[0]).map(cell => cell.trim());
-                const headerIndex = new Map();
-                headers.forEach((header, idx) => {
-                    headerIndex.set(normalize(header), idx);
-                });
-
-                const getValue = (columns, names) => {
-                    const keys = Array.isArray(names) ? names : [names];
-                    for (const name of keys) {
-                        const idx = headerIndex.get(normalize(name));
-                        if (idx !== undefined && columns[idx] !== undefined) {
-                            return columns[idx].trim();
-                        }
-                    }
-                    return '';
-                };
-
-                const toInt = (value) => {
-                    const num = parseInt(value, 10);
-                    return Number.isNaN(num) ? null : num;
-                };
-
-                lines.slice(1).forEach(line => {
-                    const columns = parseLine(line);
-                    if (!columns.length) return;
-
-                    const pos = getValue(columns, 'POS');
-                    const sleeperId = getValue(columns, 'SLPR_ID');
-                    const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
-
-                    if (pos === 'RDP') {
-                        const pickName = getValue(columns, 'PLAYER NAME');
-                        if (pickName) {
-                            dataMap[pickName] = { ktc: ktcValue };
-                        }
-                        return;
-                    }
-
-                    if (!sleeperId || sleeperId === 'NA') return;
-
-                    dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
-                });
-
-                return dataMap;
-            }
-
-            async function fetchUserAndLeagues(username) {
-                const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
-                if (!user || !user.user_id) throw new Error('Sleeper user not found.');
-                state.userId = user.user_id;
-
-                const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${new Date().getFullYear()}`);
-                if (!leagues || leagues.length === 0) throw new Error('No active leagues found for this user in the current season.');
-                state.leagues = leagues.sort((a,b) => a.name.localeCompare(b.name));
-
-                populateLeagueSelect(state.leagues);
-            }
-
-            async function analyzeLeague(leagueId) {
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                state.currentLeagueId = leagueId;
-
-                const leagueInfo = state.leagues.find(l => l.league_id === leagueId);
-                const qbSlots = leagueInfo.roster_positions.filter(p => p === 'QB').length;
-                const superflexSlots = leagueInfo.roster_positions.filter(p => p === 'SUPER_FLEX').length;
-                state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
-
-                const [rosters, users, tradedPicks] = await Promise.all([
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`)
-                ]);
-
-                const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
-                
-                infographicContent.classList.remove('hidden');
-                summaryStats.classList.remove('hidden');
-                
-                renderSummaryStats(teams);
-                renderCharts(teams);
-                renderRadarChart(teams);
-                renderStarterGrid(teams, leagueInfo);
-
-                setLoading(false);
-            }
-
-            function processLeagueData(rosters, users, tradedPicks, leagueInfo) {
-                const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
-
-                return rosters.map(roster => {
-                    const owner = userMap[roster.owner_id];
-                    const teamName = owner?.display_name || `Team ${roster.roster_id}`;
-                    
-                    let topPlayer = { name: 'N/A', ktc: 0 };
-                    const allPlayers = (roster.players || []).map(pId => {
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        if (ktc > topPlayer.ktc) {
-                            topPlayer = { name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown', ktc };
-                        }
-                        return { id: pId, pos: playerInfo?.position, ktc };
-                    }).sort((a,b) => b.ktc - a.ktc);
-
-                    const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
-                    allPlayers.forEach(p => {
-                        if (overallPositional.hasOwnProperty(p.pos)) {
-                            overallPositional[p.pos] += p.ktc;
-                        }
-                    });
-                    
-                    getOwnedPicks(roster.roster_id, rosters, tradedPicks, leagueInfo).forEach(p => {
-                        overallPositional.Picks += getKtcValue(p.label);
-                    });
-
-                    const startersPositional = { QB: 0, RB: 0, WR: 0, TE: 0, FLEX: 0, 'SUPER_FLEX': 0 };
-                    const startersPlayerDetails = { QB: [], RB: [], WR: [], TE: [], FLEX: [], 'SUPER_FLEX': [] };
-                    const startersValueByPosition = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                    const starterIds = roster.starters || [];
-                    const rosterPositions = leagueInfo.roster_positions;
-                    starterIds.forEach((pId, index) => {
-                        const slot = rosterPositions[index];
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        
-                        // For stacked bar chart
-                        if (startersPositional.hasOwnProperty(slot)) {
-                            startersPositional[slot] += ktc;
-                            startersPlayerDetails[slot].push({
-                                name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown',
-                                ktc: ktc
-                            });
-                        }
-
-                        // For summary rank calculation
-                        if (playerInfo && startersValueByPosition.hasOwnProperty(playerInfo.position)) {
-                            startersValueByPosition[playerInfo.position] += ktc;
-                        }
-                    });
-                    
-                    const totalValue = Object.values(overallPositional).reduce((a, b) => a + b, 0);
-
-                    return {
-                        teamName,
-                        totalValue,
-                        startersValue: Object.values(startersPositional).reduce((a,b) => a+b, 0),
-                        overallPositional,
-                        startersPositional,
-                        startersPlayerDetails,
-                        startersValueByPosition,
-                        roster,
-                        topPlayer,
-                        allPlayers,
-                        isUserTeam: roster.owner_id === state.userId
-                    };
-                }).sort((a,b) => b.totalValue - a.totalValue);
-            }
-
-            function getOwnedPicks(rosterId, allRosters, tradedPicks, leagueInfo) {
-                const currentYear = new Date().getFullYear();
-                const all_picks = [];
-
-                // 1. Generate all original picks for every team for the next 4 years
-                for (const r of allRosters) {
-                    for (let i = 1; i <= 4; i++) {
-                        const season = currentYear + i;
-                        for (let round = 1; round <= leagueInfo.settings.draft_rounds; round++) {
-                            all_picks.push({
-                                season: season.toString(),
-                                round: round,
-                                roster_id: r.roster_id, // Original owner
-                                owner_id: r.roster_id    // Current owner (by default)
-                            });
-                        }
-                    }
-                }
-
-                // 2. Account for trades
-                tradedPicks.forEach(trade => {
-                    const pickIndex = all_picks.findIndex(p =>
-                        p.season === trade.season &&
-                        p.round === trade.round &&
-                        p.roster_id === trade.roster_id
-                    );
-                    if (pickIndex !== -1) {
-                        all_picks[pickIndex].owner_id = trade.owner_id;
-                    }
-                });
-
-                // 3. Filter for picks owned by the current roster
-                return all_picks
-                    .filter(p => p.owner_id === rosterId)
-                    .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
-                    .map(p => ({ ...p, label: `${p.season} Mid ${ordinal(p.round)}` }));
-            }
-
-            // --- UI Rendering ---
-            function renderSummaryStats(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) {
-                    summaryStats.classList.add('hidden');
-                    return;
-                }
-
-                const sortedByStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                
-                const totalRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-                const starterRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-
-                const positionsToRank = ['QB', 'RB', 'WR', 'TE'];
-                const positionalRanks = {};
-                positionsToRank.forEach(pos => {
-                    const sorted = [...teams].sort((a,b) => b.startersValueByPosition[pos] - a.startersValueByPosition[pos]);
-                    positionalRanks[pos] = sorted.findIndex(t => t.isUserTeam) + 1;
-                });
-
-                summaryStats.innerHTML = `
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Overall Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(totalRank, teams.length)}">${totalRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters KTC</p>
-                        <p class="text-lg font-bold">${userTeam.startersValue.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(starterRank, teams.length)}">${starterRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Top Player</p>
-                        <p class="text-sm font-bold truncate">${userTeam.topPlayer.name}</p>
-                        <p class="text-[10px] text-purple-400">${userTeam.topPlayer.ktc.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">QB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.QB, teams.length)}">${positionalRanks.QB}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">RB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.RB, teams.length)}">${positionalRanks.RB}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">WR Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.WR, teams.length)}">${positionalRanks.WR}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">TE Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.TE, teams.length)}">${positionalRanks.TE}/${teams.length}</p>
-                    </div>
-                `;
-            }
-            
-            function renderCharts(teams) {
-                const labels = teams.map(t => {
-                    const name = t.teamName;
-                    return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                });
-
-                // Overall Chart
-                const overallDatasets = Object.keys(teams[0].overallPositional).map(pos => ({
-                    label: pos,
-                    data: teams.map(t => t.overallPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                if(overallChart) overallChart.destroy();
-                const overallMaxKtc = Math.max(...teams.map(t => t.totalValue));
-                overallChart = new Chart(document.getElementById('overallValueChart'), {
-                    type: 'bar',
-                    data: { labels, datasets: overallDatasets },
-                    options: chartOptions(null, overallMaxKtc)
-                });
-
-                // Starters Chart
-                const sortedStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                const startersLabels = sortedStarters.map(t => t.teamName);
-                const startersDatasets = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].map(pos => ({
-                    label: pos,
-                    data: sortedStarters.map(t => t.startersPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                
-                const startersMaxKtc = Math.max(...sortedStarters.map(t => t.startersValue));
-
-                if(startersChart) startersChart.destroy();
-                startersChart = new Chart(document.getElementById('startersValueChart'), {
-                    type: 'bar',
-                    data: {
-                        labels: sortedStarters.map(t => {
-                            const name = t.teamName;
-                            return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                        }),
-                        datasets: startersDatasets
-                    },
-                    options: chartOptions(sortedStarters, startersMaxKtc) // Pass sorted teams and max value
-                });
-            }
-
-            function renderRadarChart(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) return;
-
-                const leagueAverages = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const userValues = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const positions = ['QB', 'RB', 'WR', 'TE'];
-
-                positions.forEach(pos => {
-                    let totalLeagueKTC = 0;
-                    teams.forEach(team => {
-                        const topTwoPlayers = team.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                        totalLeagueKTC += topTwoPlayers.reduce((sum, player) => sum + player.ktc, 0);
-                    });
-                    leagueAverages[pos] = totalLeagueKTC / teams.length;
-
-                    const userTopTwo = userTeam.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                    userValues[pos] = userTopTwo.reduce((sum, player) => sum + player.ktc, 0);
-                });
-                
-                if(radarChart) radarChart.destroy();
-                radarChart = new Chart(document.getElementById('radarChart'), {
-                    type: 'radar',
-                    data: {
-                        labels: positions,
-                        datasets: [
-                            {
-                                label: 'Your Team (Top 2)',
-                                data: Object.values(userValues),
-                                fill: true,
-                                backgroundColor: 'rgba(118, 109, 255, 0.4)',
-                                borderColor: 'rgba(118, 109, 255, 1)',
-                                pointBackgroundColor: 'rgba(118, 109, 255, 1)',
-                                pointBorderColor: '#fff',
-                            },
-                            {
-                                label: 'League Average (Top 2)',
-                                data: Object.values(leagueAverages),
-                                fill: true,
-                                backgroundColor: 'rgba(66, 194, 255, 0.4)',
-                                borderColor: 'rgba(66, 194, 255, 1)',
-                                pointBackgroundColor: 'rgba(66, 194, 255, 1)',
-                                pointBorderColor: '#fff',
-                            }
-                        ]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        elements: {
-                            line: {
-                                borderWidth: 3
-                            }
-                        },
-                        scales: {
-                            r: {
-                                angleLines: { color: 'rgba(255, 255, 255, 0.2)' },
-                                grid: { color: 'rgba(255, 255, 255, 0.2)' },
-                                pointLabels: {
-                                    font: { size: 14, family: "'Orbitron', sans-serif" },
-                                    color: '#EAEBF0'
-                                },
-                                ticks: {
-                                    color: '#EAEBF0',
-                                    backdropColor: 'rgba(0,0,0,0.5)',
-                                    font: { family: "'Roboto', sans-serif" }
-                                }
-                            }
-                        },
-                        plugins: {
-                             legend: {
-                                position: 'top',
-                                labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                            }
-                        }
-                    }
-                });
-            }
-
-            function renderStarterGrid(teams, leagueInfo) {
-                starterRankingsGrid.innerHTML = '';
-
-                const starterPositions = {};
-                leagueInfo.roster_positions.forEach(pos => {
-                    if (['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].includes(pos)) {
-                        starterPositions[pos] = (starterPositions[pos] || 0) + 1;
-                    }
-                });
-
-                Object.entries(starterPositions).forEach(([slotPosition, count]) => {
-                    for (let i = 0; i < count; i++) {
-                        const slotIndex = i + 1;
-                        const slotData = [];
-
-                        teams.forEach(team => {
-                            const starters = team.roster.starters || [];
-                            const positions = leagueInfo.roster_positions;
-                            let playerFound = false;
-                            let currentSlotCount = 0;
-
-                            for (let j = 0; j < starters.length; j++) {
-                                if (positions[j] === slotPosition) {
-                                    currentSlotCount++;
-                                    if (currentSlotCount === slotIndex) {
-                                        const playerId = starters[j];
-                                        const playerInfo = state.players[playerId];
-                                        const ktcValue = getKtcValue(playerId);
-                                        slotData.push({
-                                            teamName: team.teamName,
-                                            playerName: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name} ${playerInfo.last_name}` : 'Empty Slot',
-                                            ktcValue: ktcValue,
-                                        });
-                                        playerFound = true;
-                                        break;
-                                    }
-                                }
-                            }
-                             if (!playerFound) {
-                                slotData.push({ teamName: team.teamName, playerName: 'Empty Slot', ktcValue: 0 });
-                            }
-                        });
-
-                        slotData.sort((a, b) => b.ktcValue - a.ktcValue);
-
-                        const gridItem = document.createElement('div');
-                        gridItem.className = 'glass-panel p-3';
-
-                        let content = `<h3 class="text-lg font-bold text-center mb-2">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
-                        slotData.forEach((data, index) => {
-                            const rank = index + 1;
-                            const color = getRankColor(rank, teams.length);
-                            content += `
-                                <li class="flex justify-between items-center text-xs py-0.5 border-b border-gray-800/50 gap-2">
-                                    <div class="flex items-center gap-2 w-3/5 min-w-0">
-                                        <span class="font-bold w-6 flex-shrink-0" style="color: ${color};">${rank}.</span>
-                                        <span class="truncate">${data.teamName}</span>
-                                    </div>
-                                    <div class="text-right flex-shrink-0 w-2/5">
-                                        <span class="font-semibold" style="color: ${color};">${data.ktcValue.toLocaleString()}</span>
-                                        <p class="text-xs text-gray-500 truncate">${data.playerName}</p>
-                                    </div>
-                                </li>
-                            `;
-                        });
-                        content += '</ul>';
-                        gridItem.innerHTML = content;
-                        starterRankingsGrid.appendChild(gridItem);
-                    }
-                });
-            }
-
-            // --- Charting ---
-            function chartOptions(teamsDataForTooltip = null, maxKtc = 0) {
-                const tooltipOptions = {
-                     backgroundColor: 'rgba(13, 14, 27, 0.9)',
-                     titleFont: { family: "'Orbitron', sans-serif", size: 16 },
-                     bodyFont: { family: "'Roboto', sans-serif", size: 12 },
-                     footerFont: { family: "'Roboto', sans-serif", weight: 'bold' },
-                     borderColor: 'rgba(118, 109, 255, 0.5)',
-                     borderWidth: 1,
-                     padding: 10,
-                     callbacks: {}
-                };
-
-                if (teamsDataForTooltip) {
-                    tooltipOptions.callbacks.footer = (tooltipItems) => {
-                        const teamIndex = tooltipItems[0].dataIndex;
-                        const positionLabel = tooltipItems[0].dataset.label;
-                        const teamData = teamsDataForTooltip[teamIndex];
-                        
-                        if (teamData && teamData.startersPlayerDetails && teamData.startersPlayerDetails[positionLabel]) {
-                            const players = teamData.startersPlayerDetails[positionLabel];
-                            return players
-                                .sort((a, b) => b.ktc - a.ktc)
-                                .slice(0, 3)
-                                .map(p => `${p.name}: ${p.ktc.toLocaleString()}`)
-                                .join('\n');
-                        }
-                        return '';
-                    };
-                }
-
-                return {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    indexAxis: 'y',
-                    layout: {
-                        padding: {
-                            left: 0,
-                            right: 5 
-                        }
-                    },
-                    scales: {
-                        x: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif"
-                                 },
-                                 maxRotation: 45,
-                                 minRotation: 45,
-                            },
-                            grid: { color: 'rgba(255, 255, 255, 0.1)' },
-                            max: Math.ceil(maxKtc / 10000) * 10000,
-                        },
-                        y: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif",
-                                    size: 10
-                                 },
-                                 callback: function(value, index, values) {
-                                    const label = this.getLabelForValue(value);
-                                    // The label is already truncated before being passed to the chart data
-                                    return label;
-                                }
-                            },
-                            grid: { display: false }
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            position: 'bottom',
-                            labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                        },
-                        tooltip: tooltipOptions
-                    }
-                };
-            }
-            
-            // --- KTC & Formatting Helpers ---
-            function getKtcValue(id) {
-                const ktcSource = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
-                return ktcSource[id]?.ktc || 0;
-            }
-
-            function ordinal(i) {
-                const j = i % 10, k = i % 100;
-                if (j === 1 && k !== 11) return i + "st";
-                if (j === 2 && k !== 12) return i + "nd";
-                if (j === 3 && k !== 13) return i + "rd";
-                return i + "th";
-            }
-
-            function getRankColor(rank, total) {
-                const percentile = (total - rank + 1) / total;
-                if (percentile >= 0.8) return '#00EBC7'; // Top 20%
-                if (percentile >= 0.6) return '#58A7FF';
-                if (percentile >= 0.4) return '#EAEBF0';
-                if (percentile >= 0.2) return '#FF7F50';
-                return '#FF3A75'; // Bottom 20%
-            }
-
-            // --- UI Helpers ---
-            function populateLeagueSelect(leagues) {
-                leagueSelect.innerHTML = '<option value="">Select a league...</option>';
-                leagues.forEach(league => {
-                    const option = document.createElement('option');
-                    option.value = league.league_id;
-                    option.textContent = league.name;
-                    leagueSelect.appendChild(option);
-                });
-                leagueSelect.disabled = false;
-            }
-
-            function setLoading(isLoading) {
-                if (isLoading) {
-                    loadingIndicator.classList.remove('hidden');
-                } else {
-                    loadingIndicator.classList.add('hidden');
-                }
-            }
+      </div>
+    </main>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(window.location.search);
+      const presetUsername = params.get('username');
+      const presetLeagueId = params.get('leagueId');
+
+      const usernameInput = document.getElementById('usernameInput');
+      const leagueSelect = document.getElementById('leagueSelect');
+      const loadingIndicator = document.getElementById('loading');
+      const infographicContent = document.getElementById('infographicContent');
+      const summaryStats = document.getElementById('summaryStats');
+      const startersToggleButtons = Array.from(document.querySelectorAll('#starters-panel .panel-toggle button'));
+      const leadersToggleButtons = Array.from(document.querySelectorAll('#leaders-panel .panel-toggle button'));
+      const standingsTableBody = document.querySelector('#standingsTable tbody');
+      const leadersTableBody = document.querySelector('#leadersTable tbody');
+      const radarContainer = document.getElementById('radarChartContainer');
+
+      let startersChart = null;
+      let overallChart = null;
+      let currentRadar = null;
+
+      const state = {
+        userId: null,
+        leagues: [],
+        players: {},
+        ktcOneQb: {},
+        ktcSflx: {},
+        currentLeagueId: null,
+        isSuperflex: false,
+        cache: {},
+        playerStats: {},
+        lineupDatasets: { ktc: null, ppg: null },
+        leaderboardData: {},
+        slotDefinitions: [],
+        teams: [],
+        activeStarterMode: 'ktc',
+        activeLeaderboard: 'QB',
+      };
+
+      const POS_COLORS = {
+        QB: getComputedStyle(document.documentElement).getPropertyValue('--pos-qb')?.trim() || '#FF3A75',
+        RB: getComputedStyle(document.documentElement).getPropertyValue('--pos-rb')?.trim() || '#00EBC7',
+        WR: getComputedStyle(document.documentElement).getPropertyValue('--pos-wr')?.trim() || '#58A7FF',
+        TE: getComputedStyle(document.documentElement).getPropertyValue('--pos-te')?.trim() || '#B469FF',
+        FLEX: getComputedStyle(document.documentElement).getPropertyValue('--pos-flx')?.trim() || '#BA6597',
+        SUPER_FLEX: getComputedStyle(document.documentElement).getPropertyValue('--pos-sflx')?.trim() || '#FF3A75',
+        BENCH: getComputedStyle(document.documentElement).getPropertyValue('--pos-bn')?.trim() || '#64748b',
+        Picks: '#FFC700',
+      };
+
+      usernameInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          handleFetchData();
+        }
+      });
+
+      leagueSelect.addEventListener('change', () => {
+        if (leagueSelect.value) {
+          analyzeLeague(leagueSelect.value);
+        }
+      });
+
+      startersToggleButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          if (button.dataset.mode === state.activeStarterMode) return;
+          startersToggleButtons.forEach((btn) => btn.classList.toggle('active', btn === button));
+          state.activeStarterMode = button.dataset.mode;
+          renderLineupChart();
         });
-    </script>
-    <script defer src="../scripts/app.js?v=20250826235225"></script>
+      });
+
+      leadersToggleButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const position = button.dataset.position;
+          if (state.activeLeaderboard === position) return;
+          leadersToggleButtons.forEach((btn) => {
+            const isActive = btn === button;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-selected', String(isActive));
+          });
+          state.activeLeaderboard = position;
+          renderLeaderboard();
+        });
+      });
+
+      if (presetUsername) {
+        usernameInput.value = presetUsername;
+        handleFetchData();
+      }
+      async function handleFetchData() {
+        const username = usernameInput.value.trim();
+        if (!username) {
+          alert('Please enter a Sleeper username.');
+          return;
+        }
+
+        setLoading(true);
+        infographicContent.classList.add('hidden');
+        summaryStats.classList.add('hidden');
+
+        try {
+          await Promise.all([fetchSleeperPlayers(), fetchKTCData()]);
+          await fetchUserAndLeagues(username);
+
+          if (state.leagues.length > 0) {
+            if (presetLeagueId) {
+              const leagueExists = state.leagues.some((league) => league.league_id === presetLeagueId);
+              if (leagueExists) {
+                leagueSelect.value = presetLeagueId;
+                await analyzeLeague(presetLeagueId);
+              } else {
+                alert('The specified league was not found for this user.');
+              }
+            } else {
+              leagueSelect.selectedIndex = 1;
+              await analyzeLeague(state.leagues[0].league_id);
+            }
+          }
+        } catch (error) {
+          console.error('Error fetching data:', error);
+          alert(`An error occurred: ${error.message}`);
+        } finally {
+          setLoading(false);
+        }
+      }
+
+      async function analyzeLeague(leagueId) {
+        setLoading(true);
+        infographicContent.classList.add('hidden');
+        summaryStats.classList.add('hidden');
+
+        try {
+          const leagueInfo = state.leagues.find((league) => league.league_id === leagueId);
+          if (!leagueInfo) throw new Error('League metadata missing.');
+
+          const qbSlots = leagueInfo.roster_positions.filter((pos) => pos === 'QB').length;
+          const superflexSlots = leagueInfo.roster_positions.filter((pos) => pos === 'SUPER_FLEX').length;
+          state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
+          state.currentLeagueId = leagueId;
+
+          const [rosters, users, tradedPicks] = await Promise.all([
+            fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
+            fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
+            fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`),
+          ]);
+
+          const season = leagueInfo.season || String(new Date().getFullYear());
+          const stats = await fetchSeasonStats(season);
+
+          const processed = processLeagueData({ rosters, users, tradedPicks, leagueInfo, stats });
+          state.teams = processed.teams;
+          state.slotDefinitions = processed.slotDefinitions;
+          state.lineupDatasets = processed.lineupDatasets;
+          state.leaderboardData = processed.leaderboardData;
+
+          renderSummaryStats();
+          renderLineupChart();
+          renderOverallChart();
+          renderRadarChart(processed.radarSeries);
+          renderStandings(processed.standings);
+          renderLeaderboard();
+
+          infographicContent.classList.remove('hidden');
+          summaryStats.classList.remove('hidden');
+        } catch (error) {
+          console.error('League analysis error:', error);
+          alert(`Unable to analyze league: ${error.message}`);
+        } finally {
+          setLoading(false);
+        }
+      }
+
+      async function fetchWithCache(url) {
+        if (state.cache[url]) return state.cache[url];
+        const response = await fetch(url);
+        if (!response.ok) throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+        const data = await response.json();
+        state.cache[url] = data;
+        return data;
+      }
+
+      async function fetchSleeperPlayers() {
+        if (Object.keys(state.players).length > 0) return;
+        state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
+      }
+
+      async function fetchKTCData() {
+        if (Object.keys(state.ktcOneQb).length > 0) return;
+        const sheetId = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
+        const [oneQbCsv, sflxCsv] = await Promise.all([
+          fetch(`https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then((res) => {
+            if (!res.ok) throw new Error('Failed to fetch 1QB KTC data.');
+            return res.text();
+          }),
+          fetch(`https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then((res) => {
+            if (!res.ok) throw new Error('Failed to fetch SFLX KTC data.');
+            return res.text();
+          }),
+        ]);
+        state.ktcOneQb = parseSheetData(oneQbCsv);
+        state.ktcSflx = parseSheetData(sflxCsv);
+      }
+
+      async function fetchUserAndLeagues(username) {
+        const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
+        if (!user || !user.user_id) throw new Error('Sleeper user not found.');
+        state.userId = user.user_id;
+
+        const year = new Date().getFullYear();
+        const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${year}`);
+        if (!leagues || leagues.length === 0) throw new Error('No active leagues found for this user in the current season.');
+
+        state.leagues = leagues.sort((a, b) => a.name.localeCompare(b.name));
+        populateLeagueSelect(state.leagues);
+      }
+
+      async function fetchSeasonStats(season) {
+        if (state.playerStats[season]) return state.playerStats[season];
+        const stats = await fetchWithCache(`https://api.sleeper.app/v1/stats/nfl/regular/${season}?season_type=regular`);
+        state.playerStats[season] = stats || {};
+        return state.playerStats[season];
+      }
+      function processLeagueData({ rosters, users, leagueInfo, stats }) {
+        const userMap = users.reduce((map, user) => {
+          map[user.user_id] = user;
+          return map;
+        }, {});
+
+        const slotDefinitions = buildSlotDefinitions(leagueInfo.roster_positions || []);
+
+        const teams = rosters.map((roster) => {
+          const owner = userMap[roster.owner_id];
+          const teamName = owner?.display_name || `Team ${roster.roster_id}`;
+          const isUserTeam = roster.owner_id === state.userId;
+
+          const playerMetrics = (roster.players || []).map((playerId) => {
+            const player = state.players[playerId] || {};
+            const statLine = stats?.[playerId] || {};
+            const ktc = getKtcValue(playerId);
+            const totalPoints = parseFloat(statLine.pts_ppr ?? statLine.pts_ppr_total ?? statLine.fpts ?? statLine.pts_std ?? 0) || 0;
+            const gamesPlayed = parseFloat(statLine.gp ?? statLine.games_played ?? statLine.played ?? 0) || 0;
+            const ppg = gamesPlayed > 0 ? totalPoints / gamesPlayed : 0;
+            return {
+              id: playerId,
+              pos: player.position || 'UNK',
+              name: formatPlayerName(player),
+              ktc,
+              totalPoints,
+              gamesPlayed,
+              ppg,
+            };
+          });
+
+          const sortedByKtc = [...playerMetrics].sort((a, b) => b.ktc - a.ktc);
+          const slotAssignments = assignSlots(slotDefinitions, sortedByKtc);
+
+          const startersByPosition = aggregateSlotValues(slotAssignments, 'ktc');
+          const startersPpgByPosition = aggregateSlotValues(slotAssignments, 'ppg');
+
+          const overallPositional = playerMetrics.reduce((acc, player) => {
+            const key = normalizePositionKey(player.pos);
+            acc[key] = (acc[key] || 0) + player.ktc;
+            return acc;
+          }, {});
+
+          const topPlayer = sortedByKtc[0] || { name: 'N/A', ktc: 0 };
+
+          const settings = roster.settings || {};
+          const wins = settings.wins ?? 0;
+          const losses = settings.losses ?? 0;
+          const ties = settings.ties ?? 0;
+          const pf = parseFloat(settings.fpts || 0) + parseFloat(settings.fpts_decimal || 0) / 100;
+          const pa = parseFloat(settings.fpts_against || 0) + parseFloat(settings.fpts_against_decimal || 0) / 100;
+
+          return {
+            teamName,
+            isUserTeam,
+            startersByPosition,
+            startersPpgByPosition,
+            overallPositional,
+            slotAssignments,
+            playerMetrics,
+            topPlayer,
+            totalValue: playerMetrics.reduce((sum, player) => sum + player.ktc, 0),
+            startersValue: Object.values(startersByPosition).reduce((sum, value) => sum + value, 0),
+            standings: { wins, losses, ties, pf, pa },
+            totalFantasyPoints: pf,
+          };
+        });
+
+        const slotValueMatrix = buildSlotMatrix(teams, slotDefinitions);
+
+        return {
+          teams,
+          slotDefinitions,
+          lineupDatasets: buildLineupDatasets(teams, slotDefinitions),
+          leaderboardData: buildLeaderboards(teams),
+          standings: buildStandings(teams),
+          radarSeries: buildRadarSeries({ slotDefinitions, slotValueMatrix }),
+        };
+      }
+
+      function buildSlotDefinitions(rosterPositions) {
+        const counts = {};
+        return (rosterPositions || [])
+          .filter((slot) => !['BN', 'IR', 'TAXI'].includes(slot))
+          .map((slot) => {
+            counts[slot] = (counts[slot] || 0) + 1;
+            const label = counts[slot] > 1 ? `${slot.replace('_', ' ')} ${counts[slot]}` : slot.replace('_', ' ');
+            return {
+              slot,
+              key: `${slot}_${counts[slot]}`,
+              label,
+              eligible: deriveEligiblePositions(slot),
+            };
+          });
+      }
+
+      function deriveEligiblePositions(slot) {
+        if (slot === 'FLEX') return ['RB', 'WR', 'TE'];
+        if (slot === 'SUPER_FLEX' || slot === 'OP') return ['QB', 'RB', 'WR', 'TE'];
+        if (slot === 'WRRB_FLEX') return ['RB', 'WR'];
+        if (slot === 'REC_FLEX') return ['WR', 'TE'];
+        if (slot === 'DST') return ['DEF'];
+        if (slot === 'K') return ['K'];
+        return [slot.replace('_', '')];
+      }
+
+      function assignSlots(slotDefinitions, sortedPlayers) {
+        const used = new Set();
+        return slotDefinitions.map((slot) => {
+          let candidate = null;
+
+          if (slot.slot === 'SUPER_FLEX') {
+            candidate = sortedPlayers.find((player) => !used.has(player.id) && player.pos === 'QB');
+          }
+
+          if (!candidate) {
+            candidate = sortedPlayers.find((player) => !used.has(player.id) && slot.eligible.includes(player.pos));
+          }
+
+          if (!candidate && slot.slot === 'SUPER_FLEX') {
+            candidate = sortedPlayers.find((player) => !used.has(player.id) && ['RB', 'WR', 'TE'].includes(player.pos));
+          }
+
+          if (candidate) {
+            used.add(candidate.id);
+          }
+
+          return {
+            slot,
+            key: slot.key,
+            label: slot.label,
+            player: candidate,
+            ktc: candidate?.ktc || 0,
+            ppg: candidate?.ppg || 0,
+          };
+        });
+      }
+
+      function aggregateSlotValues(slotAssignments, metricKey) {
+        return slotAssignments.reduce((acc, assignment) => {
+          const key = normalizePositionKey(assignment.slot.slot);
+          acc[key] = (acc[key] || 0) + (assignment[metricKey] || 0);
+          return acc;
+        }, {});
+      }
+
+      function normalizePositionKey(position) {
+        if (position === 'WRRB_FLEX' || position === 'REC_FLEX') return 'FLEX';
+        return position;
+      }
+
+      function buildSlotMatrix(teams, slotDefinitions) {
+        return teams.map((team) => {
+          const row = { isUserTeam: team.isUserTeam, teamName: team.teamName };
+          slotDefinitions.forEach((slot, index) => {
+            const assignment = team.slotAssignments[index];
+            row[slot.key] = {
+              ktc: assignment?.ktc || 0,
+              ppg: assignment?.ppg || 0,
+            };
+          });
+          return row;
+        });
+      }
+
+      function buildLineupDatasets(teams, slotDefinitions) {
+        const order = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
+        const basePositions = Array.from(
+          new Set(
+            slotDefinitions.map((slot) => normalizePositionKey(slot.slot)).filter((pos) => order.includes(pos))
+          )
+        );
+
+        const sortedTeams = [...teams].sort((a, b) => b.startersValue - a.startersValue);
+        const labels = sortedTeams.map((team) => (team.teamName.length > 16 ? `${team.teamName.slice(0, 16)}…` : team.teamName));
+
+        const buildForMetric = (metric) => {
+          const datasets = basePositions.map((pos) => ({
+            label: pos.replace('_', ' '),
+            data: sortedTeams.map((team) => {
+              const map = metric === 'ktc' ? team.startersByPosition : team.startersPpgByPosition;
+              return map[pos] || 0;
+            }),
+            backgroundColor: (ctx) => buildBarGradient(ctx, POS_COLORS[pos] || '#58A7FF'),
+            borderRadius: 12,
+            borderSkipped: false,
+            stack: 'starter-stack',
+          }));
+
+          const max = Math.max(
+            0,
+            ...sortedTeams.map((team) => {
+              const map = metric === 'ktc' ? team.startersByPosition : team.startersPpgByPosition;
+              return Object.values(map).reduce((sum, value) => sum + value, 0);
+            })
+          );
+
+          return { labels, datasets, max };
+        };
+
+        return {
+          ktc: buildForMetric('ktc'),
+          ppg: buildForMetric('ppg'),
+        };
+      }
+
+      function buildLeaderboards(teams) {
+        const board = { QB: [], RB: [], WR: [], TE: [] };
+        teams.forEach((team) => {
+          team.playerMetrics.forEach((player) => {
+            if (!board[player.pos]) return;
+            board[player.pos].push({
+              id: player.id,
+              name: player.name,
+              owner: team.teamName,
+              totalPoints: player.totalPoints,
+              ppg: player.ppg,
+            });
+          });
+        });
+
+        Object.keys(board).forEach((pos) => {
+          board[pos].sort((a, b) => b.totalPoints - a.totalPoints || b.ppg - a.ppg);
+          board[pos] = board[pos].slice(0, 10);
+        });
+
+        return board;
+      }
+
+      function buildStandings(teams) {
+        return teams
+          .map((team) => ({
+            teamName: team.teamName,
+            isUserTeam: team.isUserTeam,
+            ...team.standings,
+          }))
+          .sort((a, b) => {
+            const pctA = computeWinPct(a.wins, a.losses, a.ties);
+            const pctB = computeWinPct(b.wins, b.losses, b.ties);
+            if (pctB !== pctA) return pctB - pctA;
+            if (b.pf !== a.pf) return b.pf - a.pf;
+            return a.teamName.localeCompare(b.teamName);
+          });
+      }
+
+      function buildRadarSeries({ slotDefinitions, slotValueMatrix }) {
+        if (!slotValueMatrix.length) return null;
+        const slotKeys = slotDefinitions.map((slot) => slot.key);
+        const slotLabels = slotDefinitions.map((slot) => slot.label);
+        const angles = computeThetaAngles(slotDefinitions.length);
+
+        const maxValues = slotKeys.map((key) => Math.max(...slotValueMatrix.map((row) => row[key]?.ktc || 0)));
+        const leagueAverages = slotKeys.map((key, index) => {
+          const total = slotValueMatrix.reduce((sum, row) => sum + (row[key]?.ktc || 0), 0);
+          return maxValues[index] > 0 ? total / slotValueMatrix.length : 0;
+        });
+
+        const userRow = slotValueMatrix.find((row) => row.isUserTeam);
+        if (!userRow) return null;
+        const userValues = slotKeys.map((key) => userRow[key]?.ktc || 0);
+
+        const normalizedUser = userValues.map((value, index) => normalizeRadarValue(value, maxValues[index]));
+        const normalizedLeague = leagueAverages.map((value, index) => normalizeRadarValue(value, maxValues[index]));
+
+        const percentiles = slotKeys.map((key, index) => {
+          const values = slotValueMatrix.map((row) => row[key]?.ktc || 0).sort((a, b) => b - a);
+          const rank = values.findIndex((value) => value <= userValues[index]) + 1 || values.length;
+          return Math.round(((values.length - rank + 1) / values.length) * 100);
+        });
+
+        return {
+          labels: slotLabels,
+          angles,
+          user: normalizedUser,
+          league: normalizedLeague,
+          text: percentiles,
+        };
+      }
+
+      function computeThetaAngles(count) {
+        const rotation = -0.55;
+        const step = 360 / count;
+        const angles = [];
+        for (let i = 0; i < count; i++) {
+          angles.push(rotation + step * i);
+        }
+        return angles;
+      }
+
+      function normalizeRadarValue(value, max) {
+        if (!max) return 0;
+        return Math.max(0, Math.min(100, (value / max) * 100));
+      }
+      function renderSummaryStats() {
+        const userTeam = state.teams.find((team) => team.isUserTeam);
+        if (!userTeam) {
+          summaryStats.classList.add('hidden');
+          return;
+        }
+
+        const sortedStarters = [...state.teams].sort((a, b) => b.startersValue - a.startersValue);
+        const sortedOverall = [...state.teams].sort((a, b) => b.totalValue - a.totalValue);
+
+        const starterRank = sortedStarters.findIndex((team) => team.isUserTeam) + 1;
+        const overallRank = sortedOverall.findIndex((team) => team.isUserTeam) + 1;
+        const totalTeams = state.teams.length;
+
+        const positionalRanks = ['QB', 'RB', 'WR', 'TE'].map((pos) => {
+          const sorted = [...state.teams].sort((a, b) => (b.startersByPosition[pos] || 0) - (a.startersByPosition[pos] || 0));
+          return { pos, rank: sorted.findIndex((team) => team.isUserTeam) + 1 };
+        });
+
+        const chips = [
+          {
+            label: 'Overall Rank',
+            value: `${overallRank}/${totalTeams}`,
+            accent: getRankColor(overallRank, totalTeams),
+          },
+          {
+            label: 'Starters KTC',
+            value: userTeam.startersValue.toLocaleString(),
+          },
+          {
+            label: 'Total FPTS',
+            value: userTeam.totalFantasyPoints.toFixed(1),
+            accent: '#42C2FF',
+          },
+          {
+            label: 'Top Player',
+            value: userTeam.topPlayer.name,
+            sub: `${userTeam.topPlayer.ktc.toLocaleString()} KTC`,
+          },
+          ...positionalRanks.map(({ pos, rank }) => ({
+            label: `${pos} Rank`,
+            value: `${rank}/${totalTeams}`,
+            accent: getRankColor(rank, totalTeams),
+          })),
+        ];
+
+        summaryStats.innerHTML = chips
+          .map((chip) => `
+            <article class="glass-panel analyzer-chip">
+              <p class="chip-label">${chip.label}</p>
+              <p class="chip-value" style="color:${chip.accent || 'inherit'}">${chip.value}</p>
+              ${chip.sub ? `<p class="chip-sub">${chip.sub}</p>` : ''}
+            </article>
+          `)
+          .join('');
+      }
+
+      function renderLineupChart() {
+        const dataset = state.lineupDatasets[state.activeStarterMode];
+        if (!dataset) return;
+
+        if (startersChart) startersChart.destroy();
+        startersChart = new Chart(document.getElementById('startersValueChart'), {
+          type: 'bar',
+          data: { labels: dataset.labels, datasets: dataset.datasets },
+          options: createStackedBarOptions({
+            max: dataset.max,
+            horizontal: true,
+            unit: state.activeStarterMode === 'ktc' ? 'KTC' : 'PPG',
+          }),
+        });
+      }
+
+      function renderOverallChart() {
+        const labels = state.teams.map((team) => (team.teamName.length > 16 ? `${team.teamName.slice(0, 16)}…` : team.teamName));
+        const positions = Array.from(new Set(state.teams.flatMap((team) => Object.keys(team.overallPositional))));
+        const datasets = positions.map((pos) => ({
+          label: pos.replace('_', ' '),
+          data: state.teams.map((team) => team.overallPositional[pos] || 0),
+          backgroundColor: (ctx) => buildBarGradient(ctx, POS_COLORS[pos] || '#58A7FF'),
+          borderRadius: 12,
+          borderSkipped: false,
+          stack: 'overall-stack',
+        }));
+        const max = Math.max(0, ...state.teams.map((team) => team.totalValue));
+
+        if (overallChart) overallChart.destroy();
+        overallChart = new Chart(document.getElementById('overallValueChart'), {
+          type: 'bar',
+          data: { labels, datasets },
+          options: createStackedBarOptions({ max, horizontal: true, unit: 'KTC' }),
+        });
+      }
+
+      function renderRadarChart(series) {
+        if (!series) return;
+        if (currentRadar) {
+          Plotly.purge(radarContainer);
+          currentRadar = null;
+        }
+
+        const extendedAngles = [...series.angles, series.angles[0]];
+        const extendedUser = [...series.user, series.user[0]];
+        const extendedLeague = [...series.league, series.league[0]];
+
+        const bands = [100, 80, 60, 40, 20].map((radius, index) => ({
+          type: 'scatterpolar',
+          r: Array(series.labels.length + 1).fill(radius),
+          theta: extendedAngles,
+          mode: 'lines',
+          fill: 'toself',
+          opacity: 1,
+          fillcolor: ['#2c334f62', '#2D345153', '#2F365250', '#30375455', '#31385565'][index],
+          line: { color: '#525a7729', width: index === 0 ? 1 : 0.9 },
+          hoverinfo: 'skip',
+          showlegend: false,
+        }));
+
+        const userTrace = {
+          type: 'scatterpolar',
+          r: extendedUser,
+          theta: extendedAngles,
+          mode: 'lines+markers',
+          name: 'Your Team',
+          line: { color: '#6700ff', width: 2 },
+          marker: {
+            color: extendedUser.map(() => '#6300ff'),
+            size: extendedUser.map(() => 5),
+          },
+          fill: 'toself',
+          fillcolor: '#5300FF55',
+          hoverinfo: 'skip',
+        };
+
+        const leagueTrace = {
+          type: 'scatterpolar',
+          r: extendedLeague,
+          theta: extendedAngles,
+          mode: 'lines',
+          name: 'League Avg',
+          line: { color: '#42C2FF', width: 1.5 },
+          fill: 'toself',
+          fillcolor: '#42C2FF22',
+          hoverinfo: 'skip',
+        };
+
+        const textTrace = {
+          type: 'scatterpolar',
+          mode: 'text',
+          theta: series.angles,
+          r: series.user.map((value) => Math.max(0, value - 6)),
+          text: series.text.map((percent) => formatPercentileLabel(percent)),
+          textposition: 'middle center',
+          textfont: { size: 9, family: 'Bruno Ace' },
+          hoverinfo: 'skip',
+          showlegend: false,
+        };
+
+        const layout = {
+          polar: {
+            bgcolor: '#141a32',
+            radialaxis: {
+              range: [0, 100],
+              showgrid: false,
+              ticks: '',
+              showticklabels: false,
+              showline: false,
+            },
+            angularaxis: {
+              showgrid: false,
+              showline: false,
+              tickmode: 'array',
+              tickvals: series.angles,
+              ticktext: series.labels,
+              tickfont: { color: 'white', size: 10.5, family: 'Orbitron' },
+              direction: 'counterclockwise',
+              rotation: -0.55,
+              layer: 'above traces',
+            },
+          },
+          paper_bgcolor: '#141a32',
+          showlegend: false,
+          margin: { l: 45, r: 45, t: 30, b: 30 },
+          hovermode: false,
+          dragmode: false,
+        };
+
+        currentRadar = Plotly.newPlot(radarContainer, [...bands, leagueTrace, userTrace, textTrace], layout, {
+          displayModeBar: false,
+          responsive: true,
+        });
+      }
+
+      function renderStandings(standings) {
+        standingsTableBody.innerHTML = standings
+          .map((row, index) => {
+            const record = `${row.wins}-${row.losses}${row.ties ? `-${row.ties}` : ''}`;
+            return `
+              <tr class="${row.isUserTeam ? 'active-row' : ''}">
+                <td data-label="Team">${index + 1}. ${row.teamName}</td>
+                <td data-label="Record">${record}</td>
+                <td data-label="PF">${row.pf.toFixed(1)}</td>
+                <td data-label="PA">${row.pa.toFixed(1)}</td>
+              </tr>
+            `;
+          })
+          .join('');
+      }
+
+      function renderLeaderboard() {
+        const rows = state.leaderboardData[state.activeLeaderboard] || [];
+        leadersTableBody.innerHTML = rows
+          .map((row, index) => `
+            <tr>
+              <td data-label="Rank">${index + 1}</td>
+              <td data-label="Player">${row.name}</td>
+              <td data-label="Team">${row.owner}</td>
+              <td data-label="FPTS">${row.totalPoints.toFixed(1)}</td>
+              <td data-label="PPG">${row.ppg.toFixed(2)}</td>
+            </tr>
+          `)
+          .join('');
+      }
+
+      function createStackedBarOptions({ max, horizontal = false, unit = '' }) {
+        return {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: horizontal ? 'y' : 'x',
+          scales: {
+            x: {
+              stacked: true,
+              border: { display: false },
+              grid: { color: 'rgba(255, 255, 255, 0.06)' },
+              ticks: {
+                color: '#BDC1D8',
+                font: { family: 'Product Sans', size: 11 },
+              },
+              title: {
+                display: true,
+                text: unit,
+                color: '#9096C0',
+                font: { family: 'Orbitron', size: 11 },
+              },
+              max: max ? max * 1.1 : undefined,
+            },
+            y: {
+              stacked: true,
+              border: { display: false },
+              grid: { display: false },
+              ticks: {
+                color: '#EAEBF0',
+                font: { family: 'Product Sans', size: 11 },
+              },
+            },
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                color: '#EAEBF0',
+                boxWidth: 12,
+                font: { family: 'Product Sans', size: 11 },
+              },
+            },
+            tooltip: {
+              backgroundColor: 'rgba(9, 12, 28, 0.92)',
+              borderColor: 'rgba(118, 109, 255, 0.6)',
+              borderWidth: 1,
+              padding: 12,
+              titleColor: '#EAEBF0',
+              bodyColor: '#EAEBF0',
+              titleFont: { family: 'Orbitron', size: 14 },
+              bodyFont: { family: 'Product Sans', size: 12 },
+              callbacks: {
+                label: (context) => `${context.dataset.label}: ${context.formattedValue} ${unit}`.trim(),
+              },
+            },
+          },
+        };
+      }
+
+      function buildBarGradient(ctx, color) {
+        const chart = ctx.chart;
+        const area = chart.chartArea;
+        if (!area) return color;
+        const gradient = chart.ctx.createLinearGradient(area.left, area.bottom, area.right, area.top);
+        gradient.addColorStop(0, `${color}33`);
+        gradient.addColorStop(0.5, `${color}AA`);
+        gradient.addColorStop(1, color);
+        return gradient;
+      }
+      function parseSheetData(csvText) {
+        const map = {};
+        const lines = csvText.split(/\r?\n/).filter((line) => line.trim().length > 0);
+        if (!lines.length) return map;
+
+        const headers = parseCsvLine(lines[0]).map((cell) => cell.trim());
+        const headerIndex = new Map();
+        headers.forEach((header, index) => headerIndex.set(normalizeHeader(header), index));
+
+        const getValue = (columns, names) => {
+          const keys = Array.isArray(names) ? names : [names];
+          for (const name of keys) {
+            const idx = headerIndex.get(normalizeHeader(name));
+            if (idx !== undefined && columns[idx] !== undefined) return columns[idx].trim();
+          }
+          return '';
+        };
+
+        const toInt = (value) => {
+          const number = parseInt(value, 10);
+          return Number.isNaN(number) ? null : number;
+        };
+
+        lines.slice(1).forEach((line) => {
+          const columns = parseCsvLine(line);
+          if (!columns.length) return;
+
+          const sleeperId = getValue(columns, ['SLPR_ID', 'SLEEPER ID']);
+          const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
+          const pickName = getValue(columns, ['PLAYER NAME']);
+          const pos = getValue(columns, 'POS');
+
+          if (pos === 'RDP' && pickName) {
+            map[pickName] = { ktc: ktcValue ?? 0 };
+            return;
+          }
+
+          if (!sleeperId || sleeperId === 'NA') return;
+          map[sleeperId] = { ktc: ktcValue ?? 0 };
+        });
+
+        return map;
+      }
+
+      function parseCsvLine(line) {
+        const result = [];
+        let current = '';
+        let inQuotes = false;
+
+        for (let i = 0; i < line.length; i++) {
+          const char = line[i];
+          if (char === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+              current += '"';
+              i++;
+            } else {
+              inQuotes = !inQuotes;
+            }
+          } else if (char === ',' && !inQuotes) {
+            result.push(current);
+            current = '';
+          } else {
+            current += char;
+          }
+        }
+        result.push(current);
+        return result;
+      }
+
+      function normalizeHeader(header) {
+        return header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
+      }
+
+      function formatPlayerName(player) {
+        if (!player || (!player.first_name && !player.last_name)) return 'Unknown';
+        if (player.full_name) return player.full_name;
+        return `${player.first_name || ''} ${player.last_name || ''}`.trim();
+      }
+
+      function getKtcValue(playerId) {
+        const ktcSource = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
+        return ktcSource[playerId]?.ktc || 0;
+      }
+
+      function computeWinPct(wins, losses, ties) {
+        const totalGames = wins + losses + ties;
+        if (!totalGames) return 0;
+        return (wins + ties * 0.5) / totalGames;
+      }
+
+      function getRankColor(rank, total) {
+        if (!rank || !total) return '#EAEBF0';
+        const percentile = (total - rank + 1) / total;
+        if (percentile >= 0.8) return '#00EBC7';
+        if (percentile >= 0.6) return '#58A7FF';
+        if (percentile >= 0.4) return '#EAEBF0';
+        if (percentile >= 0.2) return '#FF7F50';
+        return '#FF3A75';
+      }
+
+      function formatPercentileLabel(percent) {
+        const suffix = percent % 10 === 1 && percent !== 11 ? 'st'
+          : percent % 10 === 2 && percent !== 12 ? 'nd'
+          : percent % 10 === 3 && percent !== 13 ? 'rd'
+          : 'th';
+        const color = percent >= 80 ? '#00ffaf' : percent >= 50 ? '#bcd2ff' : '#ff7f50';
+        return `<span style="color:${color};">${percent}${suffix}%</span>`;
+      }
+
+      function populateLeagueSelect(leagues) {
+        leagueSelect.innerHTML = '<option value="">Select a league...</option>';
+        leagues.forEach((league) => {
+          const option = document.createElement('option');
+          option.value = league.league_id;
+          option.textContent = league.name;
+          leagueSelect.appendChild(option);
+        });
+        leagueSelect.disabled = false;
+      }
+
+      function setLoading(isLoading) {
+        loadingIndicator.classList.toggle('hidden', !isLoading);
+      }
+    });
+  </script>
+  <script defer src="../scripts/app.js?v=20250826235225"></script>
 </body>
 </html>
-
-
-

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -5865,3 +5865,231 @@ body[data-page="research"] .app-header {
   background: rgb(67 71 87 / 63%);
 }
 
+
+/* === League Analyzer Page === */
+body[data-page="analyzer"] main#content {
+  gap: 1.5rem;
+}
+
+.analyzer-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: var(--panel-border-radius);
+  background: linear-gradient(145deg, rgba(118, 109, 255, 0.08), rgba(13, 14, 27, 0.2));
+  border: 1px solid rgba(118, 109, 255, 0.18);
+  box-shadow: 0 18px 35px rgba(6, 10, 28, 0.45);
+}
+
+.analyzer-hero h1 {
+  font-size: clamp(1.75rem, 2.5vw, 2.4rem);
+  margin: 0;
+  font-weight: 600;
+}
+
+.analyzer-hero p {
+  max-width: 48rem;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.analyzer-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(66, 194, 255, 0.12);
+  color: var(--color-accent-secondary);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.analyzer-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.analyzer-chip {
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-radius: var(--card-border-radius);
+  background: linear-gradient(145deg, rgba(22, 24, 43, 0.8), rgba(22, 24, 43, 0.45));
+  border: 1px solid rgba(118, 109, 255, 0.12);
+}
+
+.analyzer-chip .chip-label {
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.analyzer-chip .chip-value {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.analyzer-chip .chip-sub {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+}
+
+.analyzer-loading {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  font-size: 1.1rem;
+  color: var(--color-text-secondary);
+}
+
+.analyzer-panel {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel-header h2 {
+  font-size: 1.3rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.panel-header p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.panel-toggle {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 0.25rem;
+  background: rgba(118, 109, 255, 0.12);
+  border: 1px solid rgba(118, 109, 255, 0.3);
+  box-shadow: inset 0 0 12px rgba(118, 109, 255, 0.18);
+}
+
+.panel-toggle button {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  transition: all 0.2s ease;
+}
+
+.panel-toggle button:hover,
+.panel-toggle button:focus {
+  color: var(--color-text-primary);
+}
+
+.panel-toggle button.active {
+  background: linear-gradient(135deg, rgba(99, 0, 255, 0.85), rgba(0, 235, 199, 0.65));
+  color: #fff;
+  box-shadow: 0 0 12px rgba(118, 109, 255, 0.45);
+}
+
+.leaders-toggle button.active {
+  background: linear-gradient(135deg, rgba(0, 235, 199, 0.85), rgba(88, 167, 255, 0.75));
+}
+
+.chart-shell {
+  position: relative;
+  width: 100%;
+  min-height: 360px;
+}
+
+.radar-shell {
+  width: 100%;
+  min-height: 480px;
+}
+
+.table-shell {
+  overflow-x: auto;
+  border-radius: var(--card-border-radius);
+}
+
+#standingsTable,
+#leadersTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+#standingsTable thead,
+#leadersTable thead {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+#standingsTable th,
+#standingsTable td,
+#leadersTable th,
+#leadersTable td {
+  padding: 0.65rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(118, 109, 255, 0.12);
+}
+
+#standingsTable tbody tr.active-row {
+  background: rgba(66, 194, 255, 0.08);
+}
+
+#leadersTable tbody tr:hover,
+#standingsTable tbody tr:hover {
+  background: rgba(118, 109, 255, 0.08);
+}
+
+@media (max-width: 640px) {
+  #standingsTable thead,
+  #leadersTable thead {
+    display: none;
+  }
+
+  #standingsTable tr,
+  #leadersTable tr {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.35rem 0.75rem;
+    padding: 0.75rem 0;
+  }
+
+  #standingsTable td,
+  #leadersTable td {
+    border: none;
+    padding: 0.25rem 0.5rem;
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    color: var(--color-text-primary);
+  }
+
+  #standingsTable td::before,
+  #leadersTable td::before {
+    content: attr(data-label);
+    text-transform: uppercase;
+    font-size: 0.65rem;
+    color: var(--color-text-secondary);
+    letter-spacing: 0.08em;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the League Analyzer page with the research visual system, refreshed layout, and new panels for standings and positional leaders
- source Sleeper season stats to power Total FPTS summaries, lineup PPG toggling, and dynamic starter slot selection for charts and radar
- replace the Chart.js radar with a styled Plotly variant and modernize bar chart presentation to match the updated theme

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d424f22b58832ea562c052ee6cd471