### PR TITLE
Revamp league analyzer experience

### DIFF
--- a/DHP2_DeployDraft1.2/analyzer/analyzer.html
+++ b/DHP2_DeployDraft1.2/analyzer/analyzer.html
@@ -1,998 +1,212 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sleeper League KTC Infographic</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
-    <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
-    <style>
-        :root {
-            --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
-            --color-bg: #0D0E1B;
-            --color-panel-border: rgba(128, 138, 189, 0.2);
-            --color-text-primary: #EAEBF0;
-            --color-text-secondary: #9096C0;
-            --color-accent-primary: #766DFF;
-            --color-accent-primary-glow: rgba(118, 109, 255, 0.5);
-        }
-
-        body {
-            font-family: var(--font-sans);
-            background-color: var(--color-bg);
-            color: var(--color-text-primary);
-            overflow-x: hidden;
-        }
-
-        #starfield {
-            position: fixed; inset: 0; z-index: -10; pointer-events: none;
-            background: radial-gradient(ellipse at 50% 100%, #1B2735 0%, #090A0F 100%);
-        }
-
-        #stars1, #stars2, #stars3 {
-            position: absolute; left: 0; top: 0;
-            background: transparent;
-            animation: animStar linear infinite;
-        }
-
-        #stars1 { width: 1px; height: 1px; box-shadow: 1528px 425px #FFF, 1965px 1848px #FFF, 466px 588px #FFF, 1441px 1361px #FFF, 395px 1296px #FFF, 1603px 1631px #FFF, 1403px 1363px #FFF, 1010px 54px #FFF, 904px 1539px #FFF, 929px 1400px #FFF, 1370px 1286px #FFF, 612px 1109px #FFF, 1899px 1371px #FFF, 215px 873px #FFF, 1997px 882px #FFF, 283px 759px #FFF, 1675px 1005px #FFF, 145px 1973px #FFF, 1974px 1948px #FFF, 128px 1115px #FFF, 1863px 1335px #FFF, 1540px 938px #FFF, 1739px 491px #FFF, 1898px 1397px #FFF, 706px 1264px #FFF, 1505px 1162px #FFF, 200px 1889px #FFF, 1044px 1230px #FFF, 315px 1227px #FFF, 625px 217px #FFF, 1813px 1135px #FFF, 287px 791px #FFF, 1131px 816px #FFF, 845px 87px #FFF, 272px 94px #FFF, 1341px 1194px #FFF, 1547px 893px #FFF, 1460px 1971px #FFF, 655px 1052px #FFF, 1178px 815px #FFF, 1643px 1785px #FFF, 1172px 277px #FFF, 1486px 280px #FFF, 134px 1224px #FFF, 338px 213px #FFF, 814px 1844px #FFF, 1207px 806px #FFF, 14px 526px #FFF, 957px 455px #7300ff, 518px 864px #7300ff, 321px 438px #7300ff, 1226px 1328px #FFF, 784px 1010px #FF0266, 1052px 1568px #FF0266, 350px 478px #FF0266; animation-duration: 450s; }
-        #stars2 { width: 2px; height: 2px; box-shadow: 444px 26px #FFF, 644px 550px #FFF, 428px 426px #FFF, 12px 1913px #FFF, 680px 225px #FFF, 1346px 474px #FFF, 6px 1693px #FFF, 1555px 996px #FFF, 579px 1620px #FFF, 364px 1911px #FFF, 282px 1788px #FFF, 280px 337px #FFF, 1880px 1547px #FF0266, 1531px 1567px #FF0266, 193px 1099px #FF0266, 1540px 17px #FF0266, 1774px 292px #FF0266, 183px 775px #FF0266, 214px 107px #FFF, 695px 88px #FFF, 490px 1209px #FFF, 1374px 560px #FFF, 752px 1759px #FFF, 1985px 866px #FFF, 609px 310px #FFF, 86px 1036px #FFF, 638px 191px #FFF, 1635px 626px #FFF, 78px 998px #FFF, 1189px 1345px #FFF, 48px 1383px #FFF, 1981px 345px #FFF, 1993px 1838px #FFF, 717px 1540px #FFF, 287px 673px #FFF, 1821px 1665px #FFF, 686px 600px #FFF, 572px 777px #FFF, 932px 537px #FFF, 1808px 1538px #FFF, 1563px 305px #FFF, 1771px 1974px #FFF, 393px 1768px #FFF, 368px 1426px #FFF, 434px 779px #FFF, 566px 1370px #FFF, 261px 791px #FFF, 141px 434px #1ACDD1; animation-duration: 400s; }
-        #stars3 { width: 3px; height: 3px; box-shadow: 1208px 1620px #FF0070, 576px 1883px #FFF, 1810px 913px #FFF, 87px 1117px #FFF, 1076px 1851px #FFF, 859px 264px #FFF, 1469px 1346px #FFF, 1651px 1493px #FFF, 767px 822px #FFF, 359px 967px #FFF, 1009px 808px #FF0070, 100px 1656px #7300ff, 1365px 1511px #7300ff, 429px 1279px #7300ff, 1381px 1850px #E86439, 1896px 1999px #E86439, 236px 718px #7300ff, 39px 1731px #7300ff, 562px 1084px #7300ff, 1067px 1431px #FF0266, 1362px 1575px #FF0266, 953px 1860px #FF0266, 1498px 499px #FF0266, 1055px 885px #FFF, 1824px 1334px #FFF, 519px 1319px #FFF, 1716px 1538px #FFF, 1305px 524px #FFF, 808px 1972px #FFF, 426px 649px #FFF, 882px 1530px #FFF, 623px 557px #FFF, 129px 1750px #FF0070; animation-duration: 350s; }
-        
-        @keyframes animStar { from { transform: translateY(0px); } to { transform: translateY(-2000px); } }
-
-        .glass-panel {
-            background-color: rgba(13, 14, 35, 0.21);
-            background-image: linear-gradient(rgba(255,255,255, 0.03), rgba(255,255,255, 0.03));
-            backdrop-filter: blur(6px) saturate(120%) brightness(120%);
-            border: 1px solid rgba(128, 138, 189, 0.2);
-            border-radius: 10px;
-            box-shadow: inset 0 0 0 1px rgba(255,255,255, 0.05), 
-                        inset 0 0 0 2px rgba(200,200,200, 0.025), 
-                        0 10px 26px rgba(0,0,0, .22);
-        }
-        
-        h1, h2, h3 {
-            font-family: var(--font-sans);
-            color: var(--color-text-primary);
-            text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
-        }
-        h1 { font-weight: 700; }
-        h2 { font-weight: 500; }
-        h3 { font-weight: 500; }
-        
-        .chart-container {
-            position: relative;
-            height: 450px;
-            width: 100%;
-        }
-
-        .power-grid-item h3 {
-            font-size: 1rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: .8px;
-            color: var(--color-text-primary);
-            text-align: center;
-            padding: 0.2rem 0;
-            margin-bottom: 0.5rem;
-            position: relative;
-            border: 1px solid var(--color-panel-border);
-            border-radius: 5px;
-            backdrop-filter: saturate(114%) blur(1px);
-            overflow: hidden;
-        }
-
-        .power-grid-item h3::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            border-radius: inherit;
-            pointer-events: none;
-            background-color: rgba(20, 28, 58, 0.15);
-            background-image: linear-gradient(rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 35%);
-        }
-
-
-        /* Fix for browser autofill styles */
-        input:-webkit-autofill,
-        input:-webkit-autofill:hover,
-        input:-webkit-autofill:focus,
-        input:-webkit-autofill:active {
-            -webkit-box-shadow: 0 0 0 30px #0D0E1B inset !important; /* Match body bg */
-            -webkit-text-fill-color: #c4c8ea !important;
-            transition: background-color 5000s ease-in-out 0s;
-            caret-color: #c4c8ea;
-        }
-
-        #usernameInput, #leagueSelect {
-            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
-            border: 1px solid var(--color-panel-border);
-            border-radius: 8px;
-            backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-            color: #c4c8ea;
-            transition: all 0.2s ease;
-        }
-
-        #usernameInput:focus, #leagueSelect:focus {
-            outline: none;
-            border-color: var(--color-accent-primary);
-            box-shadow: 0 0 8px var(--color-accent-primary-glow);
-        }
-
-    </style>
+  <meta charset="utf-8" />
+  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+  <title>League Analyzer • Dynasty Hub</title>
+  <link href="https://fonts.googleapis.com" rel="preconnect" />
+  <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet" />
+  <link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+  <meta content="#0D0E1B" name="theme-color" />
+  <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+  <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" defer></script>
+  <script src="https://cdn.plot.ly/plotly-2.32.0.min.js" defer></script>
 </head>
-<body data-page="analyzer" class="p-2 sm:p-4">
-    <!-- Replaced Background: Starfield -->
-    <div aria-hidden="true" id="starfield">
-        <div id="stars1"></div>
-        <div id="stars2"></div>
-        <div id="stars3"></div>
+<body data-page="analyzer" class="p-2 sm:p-4 analyzer-page">
+  <div aria-hidden="true" id="starfield">
+    <div id="stars"></div>
+    <div id="stars1"></div>
+    <div id="stars2"></div>
+    <div id="stars3"></div>
+  </div>
+  <div id="noise-overlay"></div>
+  <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+      <header class="app-header glass-panel analyzer-header">
+        <div class="header-row analyzer-primary-row">
+          <div class="menu-container">
+            <button id="menu-button" class="menu-button" aria-label="Toggle navigation">
+              <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+              </svg>
+            </button>
+            <div id="dropdown-menu" class="dropdown-menu hidden">
+              <a href="../index.html">
+                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                <span>Home</span>
+              </a>
+              <a href="#" id="menu-rosters">
+                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                <span>Rosters</span>
+              </a>
+              <a href="#" id="menu-ownership">
+                <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                <span>Ownership</span>
+              </a>
+              <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+              </a>
+              <a href="#" id="menu-analyzer" class="active">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+              </a>
+            </div>
+          </div>
+          <div class="username-area">
+            <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" />
+          </div>
+          <div class="custom-select-wrapper">
+            <select id="leagueSelect" disabled>
+              <option>Select a league...</option>
+            </select>
+          </div>
+          <div class="header-quick-links" id="header-quick-links" aria-label="Quick links"></div>
+        </div>
+        <div class="header-row analyzer-secondary-row">
+          <div class="analyzer-button-slot" id="analyzer-button-slot">
+            <div class="analyzer-button-container">
+              <button aria-label="Open Rosters" class="menu-button analyzer-button" id="openRostersButton" type="button">
+                <i class="fa-solid fa-layer-group analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Rosters</span>
+              </button>
+            </div>
+          </div>
+          <div class="research-button-slot" id="research-button-slot">
+            <div class="research-button-container">
+              <button class="menu-button analyzer-button research-button" id="researchButton" type="button" aria-label="Open Research insights">
+                <i class="fa-solid fa-flask-vial analyzer-icon" aria-hidden="true"></i>
+                <span class="analyzer-label">Research</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
     </div>
-    <div id="noise-overlay"></div>
-    <div class="relative z-10 content-wrapper">
-        <div id="header-container">
-            <header class="app-header glass-panel">
-                <div class="header-row">
-                    <div class="menu-container">
-                        <button id="menu-button" class="menu-button">
-                            <svg viewBox="0 0 100 80" width="20" height="20">
-                                <rect width="100" height="15"></rect>
-                                <rect y="30" width="100" height="15"></rect>
-                                <rect y="60" width="100" height="15"></rect>
-                            </svg>
-                        </button>
-                        <div id="dropdown-menu" class="dropdown-menu hidden">
-                            <a href="../">
-                                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-                                <span>Home</span>
-                            </a>
-                            <a href="#" id="menu-rosters">
-                                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-                                <span>Rosters</span>
-                            </a>
-                            <a href="#" id="menu-ownership">
-                                <i class="fa-solid fa-percent" aria-hidden="true"></i>
-                                <span>Ownership</span>
-                            </a>
-                            <a href="#" id="menu-research">
-                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                                <span>Research</span>
-                            </a>
-                            <a href="#" id="menu-analyzer">
-                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                                <span>League Analyzer</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="username-area">
-                        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-                    </div>
-                    <div class="custom-select-wrapper">
-                        <select id="leagueSelect" disabled>
-                            <option>Select a league...</option>
-                        </select>
-                    </div>
-                </div>
+
+    <main class="container mx-auto analyzer-main" id="content">
+      <section class="analyzer-hero glass-panel">
+        <div class="hero-pill">Dynasty Hub Intelligence</div>
+        <h1>League Analyzer</h1>
+        <p>Compare team value, production and roster construction across your Sleeper dynasty leagues.</p>
+      </section>
+
+      <div id="loading" class="analyzer-loading hidden" role="status" aria-live="polite">
+        <span class="loading-pip"></span>
+        <span>Analyzing league telemetry...</span>
+      </div>
+
+      <section id="infographicContent" class="hidden analyzer-content">
+        <section id="summaryStats" class="analyzer-summary-grid" aria-label="Team summary metrics"></section>
+
+        <section class="analyzer-top-panels">
+          <article class="glass-panel analyzer-card" id="lineupPanel">
+            <header class="panel-header">
+              <div class="panel-title-stack">
+                <h2>Starting Lineup Strength</h2>
+                <p>Stacked by roster requirements</p>
+              </div>
+              <div class="toggle-pill-group" id="lineupModeToggle" role="group" aria-label="Starting lineup metric">
+                <button type="button" data-mode="value" class="toggle-pill active">Value (KTC)</button>
+                <button type="button" data-mode="ppg" class="toggle-pill">Production (PPG)</button>
+              </div>
             </header>
-        </div>
-        <main class="container mx-auto" id="content">
-            <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
-                <!-- Page Header -->
-                <header class="text-center space-y-2">
-                    <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
-                    <p class="text-md text-gray-400">KTC Team Value Analysis</p>
-                </header>
+            <div class="chart-container">
+              <canvas id="lineupChart" aria-label="Starting lineup comparison chart"></canvas>
+            </div>
+          </article>
 
-                <!-- Summary Stats -->
-                <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
-            <!-- Summary boxes injected here -->
+          <article class="glass-panel analyzer-card" id="teamValuePanel">
+            <header class="panel-header">
+              <div class="panel-title-stack">
+                <h2>Complete Roster Value</h2>
+                <p>Total KTC by positional groups</p>
+              </div>
+            </header>
+            <div class="chart-container">
+              <canvas id="teamValueChart" aria-label="Total roster value chart"></canvas>
+            </div>
+          </article>
         </section>
 
-        <!-- Loading Indicator -->
-        <div id="loading" class="hidden text-center py-8">
-            <p class="text-2xl animate-pulse">Analyzing cosmic data streams...</p>
-        </div>
+        <section class="analyzer-middle-panels">
+          <article class="glass-panel analyzer-card analyzer-radar-card" id="radarPanel">
+            <header class="panel-header">
+              <div class="panel-title-stack">
+                <h2>Roster Composition Radar</h2>
+                <p>Most valuable starters vs league average</p>
+              </div>
+            </header>
+            <div id="radarChart" class="radar-container" role="img" aria-label="Roster composition radar chart"></div>
+          </article>
 
-        <!-- Main Content -->
-        <section id="infographicContent" class="hidden space-y-6">
-            <!-- Top Level Charts -->
-            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Starting Lineup Value</h2>
-                    <div class="chart-container">
-                        <canvas id="startersValueChart"></canvas>
-                    </div>
-                </div>
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Overall Team Value</h2>
-                    <div class="chart-container">
-                        <canvas id="overallValueChart"></canvas>
-                    </div>
-                </div>
-            </section>
-            
-            <!-- Radar Chart -->
-            <section class="glass-panel p-2">
-                <h2 class="text-2xl text-center mb-4">Positional Strength</h2>
-                <div class="chart-container">
-                    <canvas id="radarChart"></canvas>
-                </div>
-            </section>
-
-            <!-- Detailed Starter Rankings -->
-            <section class="glass-panel p-6">
-                <h2 class="text-2xl text-center mb-6">Starting Position Power Grid</h2>
-                <div id="starterRankingsGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-                    <!-- Grid items will be injected here by JavaScript -->
-                </div>
-            </section>
+          <article class="glass-panel analyzer-card analyzer-standings-card" id="standingsPanel">
+            <header class="panel-header">
+              <div class="panel-title-stack">
+                <h2>League Standings</h2>
+                <p>Record, points for and against (Sleeper)</p>
+              </div>
+            </header>
+            <div class="table-scroll">
+              <table id="standingsTable" class="analyzer-table" aria-label="League standings table">
+                <thead>
+                  <tr>
+                    <th scope="col">Team</th>
+                    <th scope="col">Record</th>
+                    <th scope="col">PF</th>
+                    <th scope="col">PA</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </article>
         </section>
-    </div>
-        </main>
-    </div>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const params = new URLSearchParams(window.location.search);
-            const username = params.get('username');
-            const leagueId = params.get('leagueId');
-
-            // --- DOM Elements ---
-            const usernameInput = document.getElementById('usernameInput');
-            const leagueSelect = document.getElementById('leagueSelect');
-            const loadingIndicator = document.getElementById('loading');
-            const infographicContent = document.getElementById('infographicContent');
-            const starterRankingsGrid = document.getElementById('starterRankingsGrid');
-            const summaryStats = document.getElementById('summaryStats');
-
-
-            // --- Chart instances ---
-            let overallChart, startersChart, radarChart;
-
-            // --- State ---
-            let state = {
-                userId: null,
-                leagues: [],
-                players: {},
-                ktcOneQb: {},
-                ktcSflx: {},
-                currentLeagueId: null,
-                isSuperflex: false,
-                cache: {}
-            };
-
-            const POS_COLORS = {
-                QB: 'rgba(255, 58, 117, 0.8)',
-                RB: 'rgba(0, 235, 199, 0.8)',
-                WR: 'rgba(88, 167, 255, 0.8)',
-                TE: 'rgba(180, 105, 255, 0.8)',
-                FLEX: 'rgba(255, 127, 80, 0.8)', // Coral
-                SUPER_FLEX: 'rgba(220, 220, 220, 0.8)', // Silver
-                Picks: 'rgba(255, 199, 0, 0.8)'
-            };
-
-
-            // --- Event Listeners ---
-            usernameInput.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') {
-                    handleFetchData();
-                }
-            });
-            leagueSelect.addEventListener('change', () => {
-                if (leagueSelect.value) {
-                    analyzeLeague(leagueSelect.value);
-                }
-            });
-
-            if (username) {
-                usernameInput.value = username;
-                handleFetchData();
-            }
-
-            async function handleFetchData() {
-                const username = usernameInput.value.trim();
-                if (!username) {
-                    alert('Please enter a Sleeper username.');
-                    return;
-                }
-
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                summaryStats.classList.add('hidden');
-
-                try {
-                    // Fetch all initial data concurrently
-                    await Promise.all([
-                        fetchSleeperPlayers(),
-                        fetchKTCData()
-                    ]);
-                    
-                    await fetchUserAndLeagues(username);
-
-                    if (state.leagues.length > 0) {
-                        if (leagueId) {
-                            const leagueExists = state.leagues.some(l => l.league_id === leagueId);
-                            if (leagueExists) {
-                                leagueSelect.value = leagueId;
-                                await analyzeLeague(leagueId);
-                            } else {
-                                alert('The specified league was not found for this user.');
-                                setLoading(false);
-                            }
-                        } else {
-                            // Auto-select and analyze the first league
-                            leagueSelect.selectedIndex = 1;
-                            await analyzeLeague(state.leagues[0].league_id);
-                        }
-                    }
-                } catch (error) {
-                    console.error('Error fetching data:', error);
-                    alert(`An error occurred: ${error.message}`);
-                } finally {
-                    setLoading(false);
-                }
-            }
-
-            // --- Data Fetching ---
-            async function fetchWithCache(url) {
-                if (state.cache[url]) return state.cache[url];
-                const response = await fetch(url);
-                if (!response.ok) throw new Error(`API request failed: ${response.statusText}`);
-                const data = await response.json();
-                state.cache[url] = data;
-                return data;
-            }
-
-            async function fetchSleeperPlayers() {
-                if (Object.keys(state.players).length > 0) return;
-                state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
-            }
-
-            async function fetchKTCData() {
-                if (Object.keys(state.ktcOneQb).length > 0) return;
-                const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
-                try {
-                    const [oneQbCsv, sflxCsv] = await Promise.all([
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch 1QB KTC data: ' + res.statusText);
-                            return res.text();
-                        }),
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch SFLX KTC data: ' + res.statusText);
-                            return res.text();
-                        })
-                    ]);
-                    state.ktcOneQb = parseSheetData(oneQbCsv);
-                    state.ktcSflx = parseSheetData(sflxCsv);
-                } catch (error) {
-                     console.error("KTC Fetch Error:", error);
-                     throw new Error("Could not retrieve KTC valuation data. The proxy service may be down. Please try again later.");
-                }
-            }
-            
-            function parseSheetData(csvText) {
-                const dataMap = {};
-                const lines = csvText.split(/\r?\n/).filter(line => line.trim().length > 0);
-                if (lines.length === 0) return dataMap;
-
-                const parseLine = (line) => {
-                    const result = [];
-                    let current = '';
-                    let inQuotes = false;
-                    const sanitized = line.replace(/\r$/, '');
-
-                    for (let i = 0; i < sanitized.length; i++) {
-                        const char = sanitized[i];
-                        if (inQuotes) {
-                            if (char === '"') {
-                                if (sanitized[i + 1] === '"') {
-                                    current += '"';
-                                    i++;
-                                } else {
-                                    inQuotes = false;
-                                }
-                            } else {
-                                current += char;
-                            }
-                        } else if (char === '"') {
-                            inQuotes = true;
-                        } else if (char === ',') {
-                            result.push(current.trim());
-                            current = '';
-                        } else {
-                            current += char;
-                        }
-                    }
-                    result.push(current.trim());
-                    return result;
-                };
-
-                const normalize = (header) => header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
-                const headers = parseLine(lines[0]).map(cell => cell.trim());
-                const headerIndex = new Map();
-                headers.forEach((header, idx) => {
-                    headerIndex.set(normalize(header), idx);
-                });
-
-                const getValue = (columns, names) => {
-                    const keys = Array.isArray(names) ? names : [names];
-                    for (const name of keys) {
-                        const idx = headerIndex.get(normalize(name));
-                        if (idx !== undefined && columns[idx] !== undefined) {
-                            return columns[idx].trim();
-                        }
-                    }
-                    return '';
-                };
-
-                const toInt = (value) => {
-                    const num = parseInt(value, 10);
-                    return Number.isNaN(num) ? null : num;
-                };
-
-                lines.slice(1).forEach(line => {
-                    const columns = parseLine(line);
-                    if (!columns.length) return;
-
-                    const pos = getValue(columns, 'POS');
-                    const sleeperId = getValue(columns, 'SLPR_ID');
-                    const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
-
-                    if (pos === 'RDP') {
-                        const pickName = getValue(columns, 'PLAYER NAME');
-                        if (pickName) {
-                            dataMap[pickName] = { ktc: ktcValue };
-                        }
-                        return;
-                    }
-
-                    if (!sleeperId || sleeperId === 'NA') return;
-
-                    dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
-                });
-
-                return dataMap;
-            }
-
-            async function fetchUserAndLeagues(username) {
-                const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
-                if (!user || !user.user_id) throw new Error('Sleeper user not found.');
-                state.userId = user.user_id;
-
-                const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${new Date().getFullYear()}`);
-                if (!leagues || leagues.length === 0) throw new Error('No active leagues found for this user in the current season.');
-                state.leagues = leagues.sort((a,b) => a.name.localeCompare(b.name));
-
-                populateLeagueSelect(state.leagues);
-            }
-
-            async function analyzeLeague(leagueId) {
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                state.currentLeagueId = leagueId;
-
-                const leagueInfo = state.leagues.find(l => l.league_id === leagueId);
-                const qbSlots = leagueInfo.roster_positions.filter(p => p === 'QB').length;
-                const superflexSlots = leagueInfo.roster_positions.filter(p => p === 'SUPER_FLEX').length;
-                state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
-
-                const [rosters, users, tradedPicks] = await Promise.all([
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`)
-                ]);
-
-                const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
-                
-                infographicContent.classList.remove('hidden');
-                summaryStats.classList.remove('hidden');
-                
-                renderSummaryStats(teams);
-                renderCharts(teams);
-                renderRadarChart(teams);
-                renderStarterGrid(teams, leagueInfo);
-
-                setLoading(false);
-            }
-
-            function processLeagueData(rosters, users, tradedPicks, leagueInfo) {
-                const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
-
-                return rosters.map(roster => {
-                    const owner = userMap[roster.owner_id];
-                    const teamName = owner?.display_name || `Team ${roster.roster_id}`;
-                    
-                    let topPlayer = { name: 'N/A', ktc: 0 };
-                    const allPlayers = (roster.players || []).map(pId => {
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        if (ktc > topPlayer.ktc) {
-                            topPlayer = { name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown', ktc };
-                        }
-                        return { id: pId, pos: playerInfo?.position, ktc };
-                    }).sort((a,b) => b.ktc - a.ktc);
-
-                    const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
-                    allPlayers.forEach(p => {
-                        if (overallPositional.hasOwnProperty(p.pos)) {
-                            overallPositional[p.pos] += p.ktc;
-                        }
-                    });
-                    
-                    getOwnedPicks(roster.roster_id, rosters, tradedPicks, leagueInfo).forEach(p => {
-                        overallPositional.Picks += getKtcValue(p.label);
-                    });
-
-                    const startersPositional = { QB: 0, RB: 0, WR: 0, TE: 0, FLEX: 0, 'SUPER_FLEX': 0 };
-                    const startersPlayerDetails = { QB: [], RB: [], WR: [], TE: [], FLEX: [], 'SUPER_FLEX': [] };
-                    const startersValueByPosition = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                    const starterIds = roster.starters || [];
-                    const rosterPositions = leagueInfo.roster_positions;
-                    starterIds.forEach((pId, index) => {
-                        const slot = rosterPositions[index];
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        
-                        // For stacked bar chart
-                        if (startersPositional.hasOwnProperty(slot)) {
-                            startersPositional[slot] += ktc;
-                            startersPlayerDetails[slot].push({
-                                name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown',
-                                ktc: ktc
-                            });
-                        }
-
-                        // For summary rank calculation
-                        if (playerInfo && startersValueByPosition.hasOwnProperty(playerInfo.position)) {
-                            startersValueByPosition[playerInfo.position] += ktc;
-                        }
-                    });
-                    
-                    const totalValue = Object.values(overallPositional).reduce((a, b) => a + b, 0);
-
-                    return {
-                        teamName,
-                        totalValue,
-                        startersValue: Object.values(startersPositional).reduce((a,b) => a+b, 0),
-                        overallPositional,
-                        startersPositional,
-                        startersPlayerDetails,
-                        startersValueByPosition,
-                        roster,
-                        topPlayer,
-                        allPlayers,
-                        isUserTeam: roster.owner_id === state.userId
-                    };
-                }).sort((a,b) => b.totalValue - a.totalValue);
-            }
-
-            function getOwnedPicks(rosterId, allRosters, tradedPicks, leagueInfo) {
-                const currentYear = new Date().getFullYear();
-                const all_picks = [];
-
-                // 1. Generate all original picks for every team for the next 4 years
-                for (const r of allRosters) {
-                    for (let i = 1; i <= 4; i++) {
-                        const season = currentYear + i;
-                        for (let round = 1; round <= leagueInfo.settings.draft_rounds; round++) {
-                            all_picks.push({
-                                season: season.toString(),
-                                round: round,
-                                roster_id: r.roster_id, // Original owner
-                                owner_id: r.roster_id    // Current owner (by default)
-                            });
-                        }
-                    }
-                }
-
-                // 2. Account for trades
-                tradedPicks.forEach(trade => {
-                    const pickIndex = all_picks.findIndex(p =>
-                        p.season === trade.season &&
-                        p.round === trade.round &&
-                        p.roster_id === trade.roster_id
-                    );
-                    if (pickIndex !== -1) {
-                        all_picks[pickIndex].owner_id = trade.owner_id;
-                    }
-                });
-
-                // 3. Filter for picks owned by the current roster
-                return all_picks
-                    .filter(p => p.owner_id === rosterId)
-                    .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
-                    .map(p => ({ ...p, label: `${p.season} Mid ${ordinal(p.round)}` }));
-            }
-
-            // --- UI Rendering ---
-            function renderSummaryStats(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) {
-                    summaryStats.classList.add('hidden');
-                    return;
-                }
-
-                const sortedByStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                
-                const totalRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-                const starterRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-
-                const positionsToRank = ['QB', 'RB', 'WR', 'TE'];
-                const positionalRanks = {};
-                positionsToRank.forEach(pos => {
-                    const sorted = [...teams].sort((a,b) => b.startersValueByPosition[pos] - a.startersValueByPosition[pos]);
-                    positionalRanks[pos] = sorted.findIndex(t => t.isUserTeam) + 1;
-                });
-
-                summaryStats.innerHTML = `
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Overall Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(totalRank, teams.length)}">${totalRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters KTC</p>
-                        <p class="text-lg font-bold">${userTeam.startersValue.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(starterRank, teams.length)}">${starterRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Top Player</p>
-                        <p class="text-sm font-bold truncate">${userTeam.topPlayer.name}</p>
-                        <p class="text-[10px] text-purple-400">${userTeam.topPlayer.ktc.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">QB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.QB, teams.length)}">${positionalRanks.QB}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">RB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.RB, teams.length)}">${positionalRanks.RB}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">WR Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.WR, teams.length)}">${positionalRanks.WR}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">TE Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.TE, teams.length)}">${positionalRanks.TE}/${teams.length}</p>
-                    </div>
-                `;
-            }
-            
-            function renderCharts(teams) {
-                const labels = teams.map(t => {
-                    const name = t.teamName;
-                    return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                });
-
-                // Overall Chart
-                const overallDatasets = Object.keys(teams[0].overallPositional).map(pos => ({
-                    label: pos,
-                    data: teams.map(t => t.overallPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                if(overallChart) overallChart.destroy();
-                const overallMaxKtc = Math.max(...teams.map(t => t.totalValue));
-                overallChart = new Chart(document.getElementById('overallValueChart'), {
-                    type: 'bar',
-                    data: { labels, datasets: overallDatasets },
-                    options: chartOptions(null, overallMaxKtc)
-                });
-
-                // Starters Chart
-                const sortedStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                const startersLabels = sortedStarters.map(t => t.teamName);
-                const startersDatasets = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].map(pos => ({
-                    label: pos,
-                    data: sortedStarters.map(t => t.startersPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                
-                const startersMaxKtc = Math.max(...sortedStarters.map(t => t.startersValue));
-
-                if(startersChart) startersChart.destroy();
-                startersChart = new Chart(document.getElementById('startersValueChart'), {
-                    type: 'bar',
-                    data: {
-                        labels: sortedStarters.map(t => {
-                            const name = t.teamName;
-                            return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                        }),
-                        datasets: startersDatasets
-                    },
-                    options: chartOptions(sortedStarters, startersMaxKtc) // Pass sorted teams and max value
-                });
-            }
-
-            function renderRadarChart(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) return;
-
-                const leagueAverages = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const userValues = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const positions = ['QB', 'RB', 'WR', 'TE'];
-
-                positions.forEach(pos => {
-                    let totalLeagueKTC = 0;
-                    teams.forEach(team => {
-                        const topTwoPlayers = team.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                        totalLeagueKTC += topTwoPlayers.reduce((sum, player) => sum + player.ktc, 0);
-                    });
-                    leagueAverages[pos] = totalLeagueKTC / teams.length;
-
-                    const userTopTwo = userTeam.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                    userValues[pos] = userTopTwo.reduce((sum, player) => sum + player.ktc, 0);
-                });
-                
-                if(radarChart) radarChart.destroy();
-                radarChart = new Chart(document.getElementById('radarChart'), {
-                    type: 'radar',
-                    data: {
-                        labels: positions,
-                        datasets: [
-                            {
-                                label: 'Your Team (Top 2)',
-                                data: Object.values(userValues),
-                                fill: true,
-                                backgroundColor: 'rgba(118, 109, 255, 0.4)',
-                                borderColor: 'rgba(118, 109, 255, 1)',
-                                pointBackgroundColor: 'rgba(118, 109, 255, 1)',
-                                pointBorderColor: '#fff',
-                            },
-                            {
-                                label: 'League Average (Top 2)',
-                                data: Object.values(leagueAverages),
-                                fill: true,
-                                backgroundColor: 'rgba(66, 194, 255, 0.4)',
-                                borderColor: 'rgba(66, 194, 255, 1)',
-                                pointBackgroundColor: 'rgba(66, 194, 255, 1)',
-                                pointBorderColor: '#fff',
-                            }
-                        ]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        elements: {
-                            line: {
-                                borderWidth: 3
-                            }
-                        },
-                        scales: {
-                            r: {
-                                angleLines: { color: 'rgba(255, 255, 255, 0.2)' },
-                                grid: { color: 'rgba(255, 255, 255, 0.2)' },
-                                pointLabels: {
-                                    font: { size: 14, family: "'Orbitron', sans-serif" },
-                                    color: '#EAEBF0'
-                                },
-                                ticks: {
-                                    color: '#EAEBF0',
-                                    backdropColor: 'rgba(0,0,0,0.5)',
-                                    font: { family: "'Roboto', sans-serif" }
-                                }
-                            }
-                        },
-                        plugins: {
-                             legend: {
-                                position: 'top',
-                                labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                            }
-                        }
-                    }
-                });
-            }
-
-            function renderStarterGrid(teams, leagueInfo) {
-                starterRankingsGrid.innerHTML = '';
-
-                const starterPositions = {};
-                leagueInfo.roster_positions.forEach(pos => {
-                    if (['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].includes(pos)) {
-                        starterPositions[pos] = (starterPositions[pos] || 0) + 1;
-                    }
-                });
-
-                Object.entries(starterPositions).forEach(([slotPosition, count]) => {
-                    for (let i = 0; i < count; i++) {
-                        const slotIndex = i + 1;
-                        const slotData = [];
-
-                        teams.forEach(team => {
-                            const starters = team.roster.starters || [];
-                            const positions = leagueInfo.roster_positions;
-                            let playerFound = false;
-                            let currentSlotCount = 0;
-
-                            for (let j = 0; j < starters.length; j++) {
-                                if (positions[j] === slotPosition) {
-                                    currentSlotCount++;
-                                    if (currentSlotCount === slotIndex) {
-                                        const playerId = starters[j];
-                                        const playerInfo = state.players[playerId];
-                                        const ktcValue = getKtcValue(playerId);
-                                        slotData.push({
-                                            teamName: team.teamName,
-                                            playerName: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name} ${playerInfo.last_name}` : 'Empty Slot',
-                                            ktcValue: ktcValue,
-                                        });
-                                        playerFound = true;
-                                        break;
-                                    }
-                                }
-                            }
-                             if (!playerFound) {
-                                slotData.push({ teamName: team.teamName, playerName: 'Empty Slot', ktcValue: 0 });
-                            }
-                        });
-
-                        slotData.sort((a, b) => b.ktcValue - a.ktcValue);
-
-                        const gridItem = document.createElement('div');
-                        gridItem.className = 'glass-panel p-3';
-
-                        let content = `<h3 class="text-lg font-bold text-center mb-2">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
-                        slotData.forEach((data, index) => {
-                            const rank = index + 1;
-                            const color = getRankColor(rank, teams.length);
-                            content += `
-                                <li class="flex justify-between items-center text-xs py-0.5 border-b border-gray-800/50 gap-2">
-                                    <div class="flex items-center gap-2 w-3/5 min-w-0">
-                                        <span class="font-bold w-6 flex-shrink-0" style="color: ${color};">${rank}.</span>
-                                        <span class="truncate">${data.teamName}</span>
-                                    </div>
-                                    <div class="text-right flex-shrink-0 w-2/5">
-                                        <span class="font-semibold" style="color: ${color};">${data.ktcValue.toLocaleString()}</span>
-                                        <p class="text-xs text-gray-500 truncate">${data.playerName}</p>
-                                    </div>
-                                </li>
-                            `;
-                        });
-                        content += '</ul>';
-                        gridItem.innerHTML = content;
-                        starterRankingsGrid.appendChild(gridItem);
-                    }
-                });
-            }
-
-            // --- Charting ---
-            function chartOptions(teamsDataForTooltip = null, maxKtc = 0) {
-                const tooltipOptions = {
-                     backgroundColor: 'rgba(13, 14, 27, 0.9)',
-                     titleFont: { family: "'Orbitron', sans-serif", size: 16 },
-                     bodyFont: { family: "'Roboto', sans-serif", size: 12 },
-                     footerFont: { family: "'Roboto', sans-serif", weight: 'bold' },
-                     borderColor: 'rgba(118, 109, 255, 0.5)',
-                     borderWidth: 1,
-                     padding: 10,
-                     callbacks: {}
-                };
-
-                if (teamsDataForTooltip) {
-                    tooltipOptions.callbacks.footer = (tooltipItems) => {
-                        const teamIndex = tooltipItems[0].dataIndex;
-                        const positionLabel = tooltipItems[0].dataset.label;
-                        const teamData = teamsDataForTooltip[teamIndex];
-                        
-                        if (teamData && teamData.startersPlayerDetails && teamData.startersPlayerDetails[positionLabel]) {
-                            const players = teamData.startersPlayerDetails[positionLabel];
-                            return players
-                                .sort((a, b) => b.ktc - a.ktc)
-                                .slice(0, 3)
-                                .map(p => `${p.name}: ${p.ktc.toLocaleString()}`)
-                                .join('\n');
-                        }
-                        return '';
-                    };
-                }
-
-                return {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    indexAxis: 'y',
-                    layout: {
-                        padding: {
-                            left: 0,
-                            right: 5 
-                        }
-                    },
-                    scales: {
-                        x: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif"
-                                 },
-                                 maxRotation: 45,
-                                 minRotation: 45,
-                            },
-                            grid: { color: 'rgba(255, 255, 255, 0.1)' },
-                            max: Math.ceil(maxKtc / 10000) * 10000,
-                        },
-                        y: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif",
-                                    size: 10
-                                 },
-                                 callback: function(value, index, values) {
-                                    const label = this.getLabelForValue(value);
-                                    // The label is already truncated before being passed to the chart data
-                                    return label;
-                                }
-                            },
-                            grid: { display: false }
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            position: 'bottom',
-                            labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                        },
-                        tooltip: tooltipOptions
-                    }
-                };
-            }
-            
-            // --- KTC & Formatting Helpers ---
-            function getKtcValue(id) {
-                const ktcSource = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
-                return ktcSource[id]?.ktc || 0;
-            }
-
-            function ordinal(i) {
-                const j = i % 10, k = i % 100;
-                if (j === 1 && k !== 11) return i + "st";
-                if (j === 2 && k !== 12) return i + "nd";
-                if (j === 3 && k !== 13) return i + "rd";
-                return i + "th";
-            }
-
-            function getRankColor(rank, total) {
-                const percentile = (total - rank + 1) / total;
-                if (percentile >= 0.8) return '#00EBC7'; // Top 20%
-                if (percentile >= 0.6) return '#58A7FF';
-                if (percentile >= 0.4) return '#EAEBF0';
-                if (percentile >= 0.2) return '#FF7F50';
-                return '#FF3A75'; // Bottom 20%
-            }
-
-            // --- UI Helpers ---
-            function populateLeagueSelect(leagues) {
-                leagueSelect.innerHTML = '<option value="">Select a league...</option>';
-                leagues.forEach(league => {
-                    const option = document.createElement('option');
-                    option.value = league.league_id;
-                    option.textContent = league.name;
-                    leagueSelect.appendChild(option);
-                });
-                leagueSelect.disabled = false;
-            }
-
-            function setLoading(isLoading) {
-                if (isLoading) {
-                    loadingIndicator.classList.remove('hidden');
-                } else {
-                    loadingIndicator.classList.add('hidden');
-                }
-            }
-        });
-    </script>
-    <script defer src="../scripts/app.js?v=20250826235225"></script>
+        <section class="glass-panel analyzer-card analyzer-leaders-card" id="leadersPanel">
+          <header class="panel-header">
+            <div class="panel-title-stack">
+              <h2>League Leaders</h2>
+              <p>Top 10 scorers by position &mdash; sourced from Sleeper PPG</p>
+            </div>
+            <div class="toggle-pill-group" id="leadersToggle" role="tablist" aria-label="Position filter">
+              <button type="button" data-position="QB" class="toggle-pill active" role="tab" aria-selected="true">QB</button>
+              <button type="button" data-position="RB" class="toggle-pill" role="tab" aria-selected="false">RB</button>
+              <button type="button" data-position="WR" class="toggle-pill" role="tab" aria-selected="false">WR</button>
+              <button type="button" data-position="TE" class="toggle-pill" role="tab" aria-selected="false">TE</button>
+            </div>
+          </header>
+          <div class="table-scroll">
+            <table id="leadersTable" class="analyzer-table" aria-label="League leaders table">
+              <thead>
+                <tr>
+                  <th scope="col">Rank</th>
+                  <th scope="col">Player</th>
+                  <th scope="col">Team</th>
+                  <th scope="col">Owner</th>
+                  <th scope="col">PPG</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <script defer src="../scripts/app.js?v=20250826235225"></script>
+  <script defer src="../scripts/analyzer.js"></script>
 </body>
 </html>
-
-
-

--- a/DHP2_DeployDraft1.2/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.2/scripts/analyzer.js
@@ -1,0 +1,1046 @@
+(function () {
+  const POS_COLORS = {
+    QB: 'rgba(255, 84, 131, 0.82)',
+    RB: 'rgba(47, 220, 180, 0.82)',
+    WR: 'rgba(88, 167, 255, 0.82)',
+    TE: 'rgba(186, 142, 255, 0.82)',
+    FLEX: 'rgba(255, 179, 96, 0.8)',
+    SUPER_FLEX: 'rgba(228, 105, 255, 0.8)',
+    PICKS: 'rgba(255, 214, 84, 0.82)',
+    OTHER: 'rgba(148, 156, 199, 0.6)'
+  };
+
+  const RING_TRACES = [
+    { value: 100, fill: '#2c334f62', stroke: '#525a7739', width: 1 },
+    { value: 80, fill: '#2D345153', stroke: '#525a7729', width: 0.9 },
+    { value: 60, fill: '#2F365250', stroke: '#525a7729', width: 0.9 },
+    { value: 40, fill: '#30375455', stroke: '#525a7729', width: 0.9 },
+    { value: 20, fill: '#31385565', stroke: '#525a7735', width: 0.9 }
+  ];
+
+  const RADAR_LAYOUT = {
+    polar: {
+      bgcolor: '#141a32',
+      radialaxis: {
+        range: [0, 100],
+        showgrid: false,
+        ticks: '',
+        showticklabels: false,
+        showline: false,
+        linewidth: 0,
+        linecolor: 'rgba(0,0,0,0)'
+      },
+      angularaxis: {
+        showgrid: false,
+        showline: false,
+        tickmode: 'array',
+        tickfont: { color: 'white', size: 10.5, family: 'Orbitron' },
+        direction: 'counterclockwise',
+        rotation: -0.55,
+        layer: 'above traces'
+      }
+    },
+    paper_bgcolor: '#141a32',
+    showlegend: false,
+    margin: { l: 45, r: 45, t: 70, b: 30 },
+    hovermode: false,
+    dragmode: false
+  };
+
+  const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
+
+  function safeRound(value, precision = 1) {
+    if (!Number.isFinite(value)) return '0.0';
+    const factor = 10 ** precision;
+    return (Math.round(value * factor) / factor).toFixed(precision);
+  }
+
+  function ordinal(num) {
+    const n = Math.abs(Math.trunc(num));
+    const mod100 = n % 100;
+    if (mod100 >= 11 && mod100 <= 13) return `${n}th`;
+    switch (n % 10) {
+      case 1: return `${n}st`;
+      case 2: return `${n}nd`;
+      case 3: return `${n}rd`;
+      default: return `${n}th`;
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (document.body.dataset.page !== 'analyzer') {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const initialUsername = params.get('username') || '';
+    const initialLeague = params.get('leagueId') || '';
+
+    const usernameInput = document.getElementById('usernameInput');
+    const leagueSelect = document.getElementById('leagueSelect');
+    const loadingIndicator = document.getElementById('loading');
+    const infographicContent = document.getElementById('infographicContent');
+    const summaryStats = document.getElementById('summaryStats');
+    const lineupModeToggle = document.getElementById('lineupModeToggle');
+    const leadersToggle = document.getElementById('leadersToggle');
+    const standingsTableBody = document.querySelector('#standingsTable tbody');
+    const leadersTableBody = document.querySelector('#leadersTable tbody');
+    const openRostersButton = document.getElementById('openRostersButton');
+
+    let lineupChartInstance = null;
+    let teamValueChartInstance = null;
+
+    const state = {
+      cache: new Map(),
+      userId: null,
+      leagues: [],
+      currentLeagueId: null,
+      isSuperflex: false,
+      starterSlotPlan: [],
+      lineupMode: 'value',
+      leaderPosition: 'QB',
+      players: {},
+      ktcOneQb: {},
+      ktcSflx: {},
+      playerStats: {},
+      teams: []
+    };
+
+    usernameInput.value = initialUsername;
+
+    usernameInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        handleFetchData();
+      }
+    });
+
+    leagueSelect.addEventListener('change', () => {
+      const leagueId = leagueSelect.value;
+      if (!leagueId || leagueId === 'Select a league...') return;
+      analyzeLeague(leagueId).catch(console.error);
+    });
+
+    lineupModeToggle?.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-mode]');
+      if (!button) return;
+      const newMode = button.dataset.mode;
+      if (newMode === state.lineupMode) return;
+      state.lineupMode = newMode;
+      lineupModeToggle.querySelectorAll('button').forEach((btn) => {
+        btn.classList.toggle('active', btn.dataset.mode === newMode);
+      });
+      renderLineupChart(state.teams, state.lineupMode);
+    });
+
+    leadersToggle?.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-position]');
+      if (!button) return;
+      const position = button.dataset.position;
+      if (position === state.leaderPosition) return;
+      state.leaderPosition = position;
+      leadersToggle.querySelectorAll('button').forEach((btn) => {
+        const isActive = btn.dataset.position === position;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+      });
+      renderLeadersTable();
+    });
+
+    openRostersButton?.addEventListener('click', () => {
+      const username = usernameInput.value.trim();
+      if (!username) return;
+      if (!state.currentLeagueId) return;
+      const url = `../rosters/rosters.html?username=${encodeURIComponent(username)}&leagueId=${state.currentLeagueId}`;
+      window.location.href = url;
+    });
+
+    if (initialUsername) {
+      handleFetchData().catch(console.error);
+    }
+
+    async function handleFetchData() {
+      const username = usernameInput.value.trim();
+      if (!username) {
+        alert('Please enter a Sleeper username.');
+        return;
+      }
+
+      setLoading(true);
+      infographicContent.classList.add('hidden');
+      summaryStats.innerHTML = '';
+
+      try {
+        await Promise.all([
+          fetchSleeperPlayers(),
+          fetchKtcData()
+        ]);
+
+        await fetchUserAndLeagues(username);
+
+        if (state.leagues.length === 0) {
+          alert('No active leagues found for this user in the current season.');
+          return;
+        }
+
+        let targetLeagueId = initialLeague;
+        if (targetLeagueId && !state.leagues.some((league) => league.league_id === targetLeagueId)) {
+          targetLeagueId = '';
+        }
+
+        const leagueId = targetLeagueId || state.leagues[0].league_id;
+        leagueSelect.value = leagueId;
+        await analyzeLeague(leagueId);
+      } catch (error) {
+        console.error(error);
+        alert(error.message || 'Unable to load league data.');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    function setLoading(isLoading) {
+      loadingIndicator.classList.toggle('hidden', !isLoading);
+    }
+
+    async function fetchWithCache(url) {
+      if (state.cache.has(url)) {
+        return state.cache.get(url);
+      }
+      const response = await fetch(url, { headers: { 'User-Agent': 'DynastyHub League Analyzer' } });
+      if (!response.ok) {
+        throw new Error(`Sleeper request failed (${response.status})`);
+      }
+      const data = await response.json();
+      state.cache.set(url, data);
+      return data;
+    }
+
+    async function fetchSleeperPlayers() {
+      if (Object.keys(state.players).length > 0) return;
+      const data = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
+      state.players = data;
+    }
+
+    async function fetchKtcData() {
+      if (Object.keys(state.ktcOneQb).length > 0) return;
+      const [oneQbCsv, sflxCsv] = await Promise.all([
+        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then((res) => res.text()),
+        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then((res) => res.text())
+      ]);
+      state.ktcOneQb = parseKtcSheet(oneQbCsv);
+      state.ktcSflx = parseKtcSheet(sflxCsv);
+    }
+
+    function parseKtcSheet(csvText) {
+      const lines = csvText.split(/\r?\n/).filter(Boolean);
+      const dataMap = {};
+      if (lines.length === 0) return dataMap;
+      const headers = parseCsvLine(lines[0]);
+      const headerIndex = new Map(headers.map((header, idx) => [normalizeHeader(header), idx]));
+
+      function get(columns, headerNames) {
+        const keys = Array.isArray(headerNames) ? headerNames : [headerNames];
+        for (const key of keys) {
+          const idx = headerIndex.get(normalizeHeader(key));
+          if (idx !== undefined) {
+            const value = columns[idx];
+            if (value !== undefined) return value.trim();
+          }
+        }
+        return '';
+      }
+
+      for (let i = 1; i < lines.length; i += 1) {
+        const columns = parseCsvLine(lines[i]);
+        if (columns.length === 0) continue;
+        const pos = get(columns, 'POS');
+        const sleeperId = get(columns, 'SLPR_ID');
+        const ktcValue = parseInt(get(columns, ['VALUE', 'KTC']), 10);
+        if (pos === 'RDP') {
+          const pickName = get(columns, 'PLAYER NAME');
+          if (pickName) {
+            dataMap[pickName] = { ktc: Number.isNaN(ktcValue) ? 0 : ktcValue };
+          }
+          continue;
+        }
+        if (!sleeperId || sleeperId === 'NA') continue;
+        dataMap[sleeperId] = { ktc: Number.isNaN(ktcValue) ? 0 : ktcValue };
+      }
+      return dataMap;
+    }
+
+    function parseCsvLine(line) {
+      const result = [];
+      let current = '';
+      let inQuotes = false;
+      for (let i = 0; i < line.length; i += 1) {
+        const char = line[i];
+        if (inQuotes) {
+          if (char === '"') {
+            if (line[i + 1] === '"') {
+              current += '"';
+              i += 1;
+            } else {
+              inQuotes = false;
+            }
+          } else {
+            current += char;
+          }
+        } else if (char === '"') {
+          inQuotes = true;
+        } else if (char === ',') {
+          result.push(current.trim());
+          current = '';
+        } else {
+          current += char;
+        }
+      }
+      result.push(current.trim());
+      return result;
+    }
+
+    function normalizeHeader(value) {
+      return value.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
+    }
+
+    async function fetchUserAndLeagues(username) {
+      const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
+      if (!user?.user_id) {
+        throw new Error('Sleeper user not found.');
+      }
+      state.userId = user.user_id;
+      const year = new Date().getFullYear();
+      const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${year}`);
+      state.leagues = Array.isArray(leagues) ? leagues.sort((a, b) => a.name.localeCompare(b.name)) : [];
+      populateLeagueSelect(state.leagues);
+    }
+
+    function populateLeagueSelect(leagues) {
+      leagueSelect.innerHTML = '<option>Select a league...</option>';
+      leagues.forEach((league) => {
+        const option = document.createElement('option');
+        option.value = league.league_id;
+        option.textContent = league.name;
+        leagueSelect.appendChild(option);
+      });
+      leagueSelect.disabled = leagues.length === 0;
+    }
+
+    async function analyzeLeague(leagueId) {
+      setLoading(true);
+      infographicContent.classList.add('hidden');
+      summaryStats.innerHTML = '';
+
+      try {
+        state.currentLeagueId = leagueId;
+        const leagueInfo = state.leagues.find((league) => league.league_id === leagueId);
+        if (!leagueInfo) {
+          throw new Error('League metadata not found.');
+        }
+
+        const qbSlots = leagueInfo.roster_positions.filter((pos) => pos === 'QB').length;
+        const superflexSlots = leagueInfo.roster_positions.filter((pos) => pos === 'SUPER_FLEX').length;
+        state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
+        state.starterSlotPlan = buildStarterSlotPlan(leagueInfo.roster_positions);
+
+        const [rosters, users] = await Promise.all([
+          fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
+          fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`)
+        ]);
+
+        const season = leagueInfo.season || new Date().getFullYear().toString();
+        await hydratePlayerStats(rosters, season);
+
+        const teams = buildTeams(leagueInfo, rosters, users);
+        state.teams = teams;
+
+        renderSummaryChips(teams);
+        renderLineupChart(teams, state.lineupMode);
+        renderTeamValueChart(teams);
+        renderRadarChart(teams, leagueInfo);
+        renderStandingsTable(teams);
+        renderLeadersTable();
+
+        infographicContent.classList.remove('hidden');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    async function hydratePlayerStats(rosters, season) {
+      state.playerStats = {};
+      const uniqueIds = new Set();
+      rosters.forEach((roster) => {
+        (roster.players || []).forEach((playerId) => {
+          if (playerId) uniqueIds.add(playerId);
+        });
+      });
+      const ids = Array.from(uniqueIds);
+      const chunkSize = 25;
+      const promises = [];
+      for (let i = 0; i < ids.length; i += chunkSize) {
+        const chunk = ids.slice(i, i + chunkSize);
+        promises.push(Promise.all(chunk.map((playerId) => fetchPlayerSeasonStats(playerId, season))));
+      }
+      const results = await Promise.all(promises);
+      results.flat().forEach(({ playerId, totals }) => {
+        state.playerStats[playerId] = totals;
+      });
+    }
+
+    async function fetchPlayerSeasonStats(playerId, season) {
+      const url = `https://api.sleeper.app/v1/stats/nfl/player/${playerId}?season_type=regular&season=${season}`;
+      try {
+        const data = await fetchWithCache(url);
+        const totals = aggregatePlayerStats(data);
+        return { playerId, totals };
+      } catch (error) {
+        console.warn('Failed to fetch stats for player', playerId, error);
+        return { playerId, totals: { totalPoints: 0, gamesPlayed: 0, ppg: 0 } };
+      }
+    }
+
+    function aggregatePlayerStats(rawStats) {
+      if (!rawStats || typeof rawStats !== 'object') {
+        return { totalPoints: 0, gamesPlayed: 0, ppg: 0 };
+      }
+      let totalPoints = 0;
+      let gamesPlayed = 0;
+      const entries = Array.isArray(rawStats)
+        ? rawStats
+        : Object.values(rawStats);
+      entries.forEach((entry) => {
+        if (!entry || typeof entry !== 'object') return;
+        const pts = parseFloat(entry.pts_ppr ?? entry.pts ?? entry.pts_half_ppr ?? 0);
+        const played = parseFloat(entry.played ?? entry.gp ?? entry.games_played ?? 0);
+        if (Number.isFinite(pts)) {
+          totalPoints += pts;
+        }
+        if (Number.isFinite(played) && played > 0) {
+          gamesPlayed += played;
+        } else if (Number.isFinite(pts) && pts > 0) {
+          gamesPlayed += 1;
+        }
+      });
+      const ppg = gamesPlayed > 0 ? totalPoints / gamesPlayed : 0;
+      return { totalPoints, gamesPlayed, ppg };
+    }
+
+    function buildTeams(leagueInfo, rosters, users) {
+      const userMap = new Map(users.map((user) => [user.user_id, user]));
+      const ktcMap = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
+      const starterSlots = state.starterSlotPlan;
+
+      return rosters.map((roster) => {
+        const owner = userMap.get(roster.owner_id);
+        const displayName = owner?.display_name || `Team ${roster.roster_id}`;
+        const teamName = roster.metadata?.team_name?.trim() || displayName;
+        const rosterPlayers = roster.players || [];
+        const starters = (roster.starters || []).filter(Boolean);
+
+        const playerEntries = rosterPlayers.map((playerId) => {
+          const info = state.players[playerId];
+          const stats = state.playerStats[playerId] || { totalPoints: 0, gamesPlayed: 0, ppg: 0 };
+          const ktcEntry = ktcMap[playerId] || { ktc: 0 };
+          const position = info?.position || 'NA';
+          const name = buildPlayerName(info);
+          return {
+            id: playerId,
+            name,
+            position,
+            team: info?.team ?? 'FA',
+            ktc: ktcEntry.ktc || 0,
+            ppg: stats.ppg || 0,
+            totalPoints: stats.totalPoints || 0,
+            gamesPlayed: stats.gamesPlayed || 0
+          };
+        });
+
+        const starterDetails = buildStarterBreakdown(starters, playerEntries, cloneSlotPlan(starterSlots));
+        const overallBreakdown = buildRosterBreakdown(playerEntries);
+        const bestAssignments = assignBestLineup(playerEntries, cloneSlotPlan(starterSlots));
+
+        const totalValue = Object.values(overallBreakdown.byPosition).reduce((sum, value) => sum + value, 0);
+        const startersValue = starterDetails.totals.value;
+        const startersPpg = starterDetails.totals.ppg;
+        const record = buildRecord(roster.settings || {});
+
+        return {
+          roster,
+          owner,
+          displayName,
+          teamName,
+          playerEntries,
+          starters,
+          starterDetails,
+          starterBestAssignments: bestAssignments,
+          overallBreakdown,
+          totalValue,
+          startersValue,
+          startersPpg,
+          record,
+          isUserTeam: roster.owner_id === state.userId
+        };
+      });
+    }
+
+    function buildPlayerName(info) {
+      if (!info) return 'Unknown';
+      if (info.full_name) return info.full_name;
+      const first = info.first_name ? `${info.first_name.trim()} ` : '';
+      const last = info.last_name ? info.last_name.trim() : '';
+      const combined = `${first}${last}`.trim();
+      return combined || info.search_full_name || 'Unknown';
+    }
+
+    function buildStarterBreakdown(starters, playerEntries, slotPlan) {
+      const totals = { value: 0, ppg: 0 };
+      const valueStacks = {};
+      const ppgStacks = {};
+      const labelMap = {};
+      const workingSlots = slotPlan.map((slot) => ({ ...slot, used: false }));
+
+      starters.forEach((playerId) => {
+        const player = playerEntries.find((entry) => entry.id === playerId);
+        if (!player) return;
+        const slot = consumeSlotForPlayer(player, workingSlots);
+        const key = slot?.displayKey || player.position || 'FLEX';
+        const label = slot?.displayLabel || key;
+        labelMap[key] = label;
+        valueStacks[key] = (valueStacks[key] || 0) + player.ktc;
+        ppgStacks[key] = (ppgStacks[key] || 0) + player.ppg;
+        totals.value += player.ktc;
+        totals.ppg += player.ppg;
+      });
+
+      return {
+        totals,
+        stacks: { value: valueStacks, ppg: ppgStacks },
+        labels: labelMap
+      };
+    }
+
+    function consumeSlotForPlayer(player, slots) {
+      const position = player.position;
+      let slot = slots.find((item) => !item.used && !item.isFlex && item.primary === position);
+      if (slot) {
+        slot.used = true;
+        return slot;
+      }
+
+      if (position === 'QB') {
+        slot = slots.find((item) => !item.used && item.isSuperFlex);
+        if (slot) {
+          slot.used = true;
+          return slot;
+        }
+      }
+
+      slot = slots.find((item) => !item.used && item.isFlex && item.eligible.includes(position));
+      if (slot) {
+        slot.used = true;
+        return slot;
+      }
+
+      slot = slots.find((item) => !item.used && item.eligible.includes(position));
+      if (slot) {
+        slot.used = true;
+        return slot;
+      }
+
+      return null;
+    }
+
+    function buildRosterBreakdown(players) {
+      const byPosition = { QB: 0, RB: 0, WR: 0, TE: 0, PICKS: 0, OTHER: 0 };
+      players.forEach((player) => {
+        const pos = player.position;
+        if (byPosition[pos] === undefined) {
+          if (pos === 'K' || pos === 'DEF' || pos === 'DL' || pos === 'LB' || pos === 'DB') {
+            byPosition.OTHER += player.ktc;
+          } else {
+            byPosition.OTHER += player.ktc;
+          }
+          return;
+        }
+        byPosition[pos] += player.ktc;
+      });
+      return { byPosition };
+    }
+
+    function buildRecord(settings) {
+      const wins = Number(settings.wins || 0);
+      const losses = Number(settings.losses || 0);
+      const ties = Number(settings.ties || 0);
+      const fpts = Number(settings.fpts || 0) + Number(settings.fpts_decimal || 0) / 100;
+      const ptsAgainst = Number(settings.pts_against || 0) + Number(settings.pts_against_decimal || 0) / 100;
+      const totalGames = wins + losses + ties;
+      const winPct = totalGames > 0 ? (wins + ties * 0.5) / totalGames : 0;
+      return { wins, losses, ties, fpts, ptsAgainst, totalGames, winPct };
+    }
+
+    function assignBestLineup(players, starterSlots) {
+      const slots = starterSlots.map((slot, index) => ({ ...slot, index }));
+      const available = players.slice().sort((a, b) => b.ktc - a.ktc);
+      const used = new Set();
+      const slotTotals = {};
+      const assignments = {};
+
+      const positionBuckets = available.reduce((acc, player) => {
+        if (!acc[player.position]) acc[player.position] = [];
+        acc[player.position].push(player);
+        return acc;
+      }, {});
+
+      Object.values(positionBuckets).forEach((bucket) => bucket.sort((a, b) => b.ktc - a.ktc));
+
+      slots.forEach((slot) => {
+        let candidate = null;
+        if (slot.type === 'SUPER_FLEX') {
+          candidate = positionBuckets.QB?.find((player) => !used.has(player.id));
+          if (!candidate) {
+            candidate = available.find((player) => slot.eligible.includes(player.position) && !used.has(player.id));
+          }
+        } else if (slot.isFlex) {
+          candidate = available.find((player) => slot.eligible.includes(player.position) && !used.has(player.id));
+        } else {
+          candidate = positionBuckets[slot.primary]?.find((player) => !used.has(player.id));
+        }
+
+        if (candidate) {
+          used.add(candidate.id);
+          assignments[slot.slotKey] = candidate;
+          slotTotals[slot.slotKey] = candidate.ktc;
+        } else {
+          assignments[slot.slotKey] = null;
+          slotTotals[slot.slotKey] = 0;
+        }
+      });
+
+      return { assignments, slotTotals };
+    }
+
+    function renderSummaryChips(teams) {
+      const userTeam = teams.find((team) => team.isUserTeam);
+      if (!userTeam) {
+        summaryStats.innerHTML = '';
+        return;
+      }
+      const totalTeams = teams.length;
+
+      const valueRank = rankTeams(teams, (team) => team.totalValue, userTeam);
+      const starterRank = rankTeams(teams, (team) => team.startersValue, userTeam);
+      const ppgRank = rankTeams(teams, (team) => team.startersPpg, userTeam);
+
+      const chips = [
+        {
+          label: 'Roster KTC Value',
+          primary: userTeam.totalValue.toLocaleString(),
+          meta: `Rank ${valueRank}/${totalTeams}`
+        },
+        {
+          label: 'Starter KTC',
+          primary: userTeam.startersValue.toLocaleString(),
+          meta: `Rank ${starterRank}/${totalTeams}`
+        },
+        {
+          label: 'Starter Combined PPG',
+          primary: safeRound(userTeam.startersPpg, 2),
+          meta: `Rank ${ppgRank}/${totalTeams}`
+        },
+        {
+          label: 'Total FPTS',
+          primary: safeRound(userTeam.record.fpts, 2),
+          meta: `${userTeam.record.wins}-${userTeam.record.losses}-${userTeam.record.ties}`
+        },
+        {
+          label: 'Points Against',
+          primary: safeRound(userTeam.record.ptsAgainst, 2),
+          meta: 'Sleeper reported'
+        }
+      ];
+
+      summaryStats.innerHTML = chips.map((chip) => `
+        <article class="summary-chip">
+          <div class="chip-label">${chip.label}</div>
+          <div class="chip-primary">${chip.primary}</div>
+          <div class="chip-meta">${chip.meta}</div>
+        </article>
+      `).join('');
+    }
+
+    function rankTeams(teams, selector, targetTeam) {
+      const sorted = teams.slice().sort((a, b) => selector(b) - selector(a));
+      const index = sorted.findIndex((team) => team === targetTeam);
+      return index >= 0 ? index + 1 : teams.length;
+    }
+
+    function renderLineupChart(teams, mode) {
+      if (!Array.isArray(teams) || teams.length === 0) return;
+      const stackKeys = deriveStackKeys(state.starterSlotPlan);
+      const sorted = teams.slice().sort((a, b) => {
+        const metricA = mode === 'ppg' ? a.startersPpg : a.startersValue;
+        const metricB = mode === 'ppg' ? b.startersPpg : b.startersValue;
+        return metricB - metricA;
+      });
+      const labels = sorted.map((team) => truncateLabel(team.teamName));
+      const datasets = stackKeys.map((stack) => ({
+        label: stack.label,
+        data: sorted.map((team) => (team.starterDetails.stacks[mode]?.[stack.key] || 0)),
+        backgroundColor: POS_COLORS[stack.key] || 'rgba(148,156,199,0.6)',
+        borderRadius: 7,
+        borderSkipped: false,
+        barThickness: 'flex'
+      }));
+
+      if (lineupChartInstance) {
+        lineupChartInstance.destroy();
+      }
+
+      const context = document.getElementById('lineupChart').getContext('2d');
+      lineupChartInstance = new Chart(context, {
+        type: 'bar',
+        data: { labels, datasets },
+        options: {
+          indexAxis: 'y',
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: {
+              labels: {
+                color: '#EAEFFC',
+                font: { family: 'Product Sans', size: 11 }
+              }
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const value = context.parsed.x || 0;
+                  const suffix = mode === 'ppg' ? ' PPG' : ' KTC';
+                  return `${context.dataset.label}: ${mode === 'ppg' ? safeRound(value, 2) : Math.round(value)}${suffix}`;
+                }
+              }
+            }
+          },
+          scales: {
+            x: {
+              stacked: true,
+              ticks: {
+                color: '#C8CEEF'
+              },
+              grid: { color: 'rgba(118,109,255,0.15)' },
+              title: {
+                display: true,
+                text: mode === 'ppg' ? 'Combined Starter PPG' : 'Starter KTC Value',
+                color: '#C8CEEF',
+                font: { family: 'Product Sans', size: 12 }
+              }
+            },
+            y: {
+              stacked: true,
+              ticks: { color: '#C8CEEF' },
+              grid: { display: false }
+            }
+          }
+        }
+      });
+    }
+
+    function deriveStackKeys(slotPlan) {
+      const order = [];
+      const seen = new Set();
+      slotPlan.forEach((slot) => {
+        if (seen.has(slot.displayKey)) return;
+        seen.add(slot.displayKey);
+        order.push({ key: slot.displayKey, label: slot.displayLabel });
+      });
+      return order;
+    }
+
+    function truncateLabel(label, max = 14) {
+      if (!label) return '';
+      return label.length > max ? `${label.slice(0, max - 1)}…` : label;
+    }
+
+    function renderTeamValueChart(teams) {
+      if (!Array.isArray(teams) || teams.length === 0) return;
+      const positions = ['QB', 'RB', 'WR', 'TE', 'PICKS', 'OTHER'];
+      const labels = teams.map((team) => truncateLabel(team.teamName));
+      const datasets = positions.map((position) => ({
+        label: position,
+        data: teams.map((team) => team.overallBreakdown.byPosition[position] || 0),
+        backgroundColor: POS_COLORS[position] || 'rgba(148,156,199,0.6)',
+        borderRadius: 6,
+        borderSkipped: false
+      }));
+
+      if (teamValueChartInstance) {
+        teamValueChartInstance.destroy();
+      }
+
+      const context = document.getElementById('teamValueChart').getContext('2d');
+      teamValueChartInstance = new Chart(context, {
+        type: 'bar',
+        data: { labels, datasets },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              stacked: true,
+              ticks: { color: '#C8CEEF' },
+              grid: { display: false }
+            },
+            y: {
+              stacked: true,
+              ticks: { color: '#C8CEEF' },
+              grid: { color: 'rgba(118,109,255,0.15)' }
+            }
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: { color: '#EAEFFC', font: { family: 'Product Sans', size: 11 } }
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const value = context.parsed.y || 0;
+                  return `${context.dataset.label}: ${Math.round(value).toLocaleString()} KTC`;
+                }
+              }
+            }
+          }
+        }
+      });
+    }
+
+    function renderRadarChart(teams, leagueInfo) {
+      const userTeam = teams.find((team) => team.isUserTeam);
+      if (!userTeam) return;
+
+      const slotPlan = state.starterSlotPlan;
+      const slotLabels = slotPlan.map((slot) => slot.displayLabel);
+      const thetaAngles = buildThetaAngles(slotLabels.length);
+
+      const userValues = slotPlan.map((slot) => {
+        const player = userTeam.starterBestAssignments.assignments[slot.slotKey];
+        return player ? player.ktc : 0;
+      });
+
+      const leagueAverages = slotPlan.map((slot) => {
+        const totals = teams.reduce((sum, team) => {
+          const player = team.starterBestAssignments.assignments[slot.slotKey];
+          return sum + (player ? player.ktc : 0);
+        }, 0);
+        return totals / teams.length;
+      });
+
+      const maxReference = Math.max(...userValues, ...leagueAverages, 1);
+      const normalizedUserValues = normalizeSeries(userValues, maxReference);
+      const normalizedLeagueValues = normalizeSeries(leagueAverages, maxReference);
+      const closingTheta = [...thetaAngles, thetaAngles[0]];
+      const closingUser = [...normalizedUserValues, normalizedUserValues[0]];
+      const closingLeague = [...normalizedLeagueValues, normalizedLeagueValues[0]];
+
+      const percentTexts = slotPlan.map((slot, index) => {
+        const userVal = leagueAverages[index] > 0 ? (userValues[index] / leagueAverages[index]) * 100 : 0;
+        const clamped = Math.max(0, userVal);
+        const color = clamped >= 100 ? '#00ffaf' : '#bcd2ff';
+        return `<span style="color:${color};">${Math.round(clamped)}%</span>`;
+      });
+
+      const traces = [
+        ...RING_TRACES.map((ring) => ({
+          type: 'scatterpolar',
+          r: Array(slotLabels.length).fill(ring.value).concat([ring.value]),
+          theta: closingTheta,
+          mode: 'lines',
+          fill: 'toself',
+          opacity: 1,
+          fillcolor: ring.fill,
+          line: { color: ring.stroke, width: ring.width },
+          hoverinfo: 'skip',
+          showlegend: false
+        })),
+        {
+          type: 'scatterpolar',
+          mode: 'lines+markers',
+          name: userTeam.teamName,
+          r: closingUser,
+          theta: closingTheta,
+          line: { color: '#6700ff', width: 2 },
+          marker: {
+            color: closingTheta.map((_, idx) => (idx === closingTheta.length - 1 ? 'rgba(0,0,0,0)' : '#6300ff')),
+            size: closingTheta.map(() => 5)
+          },
+          fill: 'toself',
+          fillcolor: '#5300FF55',
+          hoverinfo: 'skip'
+        },
+        {
+          type: 'scatterpolar',
+          mode: 'lines',
+          name: 'League Average',
+          r: closingLeague,
+          theta: closingTheta,
+          line: { color: '#4bd5d1', width: 2, dash: 'dot' },
+          fill: 'toself',
+          fillcolor: '#2DFFDE33',
+          opacity: 0.75,
+          hoverinfo: 'skip'
+        },
+        {
+          type: 'scatterpolar',
+          mode: 'text',
+          theta: thetaAngles,
+          r: normalizedLeagueValues.map((value) => Math.min(94, value + 14)),
+          text: percentTexts,
+          textposition: 'middle center',
+          textfont: { size: 9, family: 'Bruno Ace' },
+          hoverinfo: 'skip',
+          showlegend: false
+        }
+      ];
+
+      const layout = {
+        ...RADAR_LAYOUT,
+        polar: {
+          ...RADAR_LAYOUT.polar,
+          angularaxis: {
+            ...RADAR_LAYOUT.polar.angularaxis,
+            tickvals: thetaAngles,
+            ticktext: slotLabels
+          }
+        },
+        annotations: [
+          {
+            xref: 'paper',
+            yref: 'paper',
+            x: 0.5,
+            y: 1.14,
+            text: userTeam.teamName,
+            showarrow: false,
+            font: { color: '#6300ff', size: 21, family: 'Orbitron' },
+            xanchor: 'center',
+            yanchor: 'bottom'
+          }
+        ]
+      };
+
+      Plotly.react('radarChart', traces, layout, { responsive: true, displayModeBar: false });
+    }
+
+    function normalizeSeries(values, maxValue) {
+      if (!values.length) return values;
+      const divisor = maxValue ?? Math.max(...values, 1);
+      const normalized = values.map((value) => (divisor > 0 ? (value / divisor) * 96 : 0));
+      return normalized;
+    }
+
+    function buildThetaAngles(length) {
+      if (length === 0) return [];
+      const step = 360 / length;
+      return Array.from({ length }, (_, idx) => parseFloat((idx * step).toFixed(2)));
+    }
+
+    function renderStandingsTable(teams) {
+      const sorted = teams.slice().sort((a, b) => {
+        if (b.record.winPct !== a.record.winPct) return b.record.winPct - a.record.winPct;
+        if (b.record.fpts !== a.record.fpts) return b.record.fpts - a.record.fpts;
+        return a.teamName.localeCompare(b.teamName);
+      });
+      standingsTableBody.innerHTML = sorted.map((team) => {
+        const record = `${team.record.wins}-${team.record.losses}-${team.record.ties}`;
+        return `
+          <tr>
+            <td>${team.teamName}</td>
+            <td>${record}</td>
+            <td>${safeRound(team.record.fpts, 2)}</td>
+            <td>${safeRound(team.record.ptsAgainst, 2)}</td>
+          </tr>
+        `;
+      }).join('');
+    }
+
+    function renderLeadersTable() {
+      const position = state.leaderPosition;
+      if (!state.teams.length) {
+        leadersTableBody.innerHTML = '<tr><td colspan="5">Load a league to view leaders.</td></tr>';
+        return;
+      }
+      const playerPool = [];
+      state.teams.forEach((team) => {
+        team.playerEntries.forEach((player) => {
+          if (player.position !== position) return;
+          if (player.gamesPlayed === 0 || player.ppg === 0) return;
+          playerPool.push({
+            ...player,
+            owner: team.teamName
+          });
+        });
+      });
+      playerPool.sort((a, b) => {
+        if (b.ppg !== a.ppg) return b.ppg - a.ppg;
+        if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
+        return a.name.localeCompare(b.name);
+      });
+      const rows = playerPool.slice(0, 10).map((player, index) => {
+        const nflTeam = player.team || 'FA';
+        return `
+          <tr>
+            <td>${index + 1}</td>
+            <td>${player.name}</td>
+            <td>${nflTeam}</td>
+            <td>${player.owner}</td>
+            <td>${safeRound(player.ppg, 2)}</td>
+          </tr>
+        `;
+      });
+      leadersTableBody.innerHTML = rows.join('') || `
+        <tr>
+          <td colspan="5">No players with recorded PPG for ${position}.</td>
+        </tr>
+      `;
+    }
+
+    function cloneSlotPlan(slotPlan) {
+      return slotPlan.map((slot) => ({ ...slot }));
+    }
+
+    function buildStarterSlotPlan(rosterPositions) {
+      const slots = [];
+      const positionCounts = {};
+      rosterPositions.forEach((position) => {
+        if (!['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].includes(position)) return;
+        positionCounts[position] = (positionCounts[position] || 0) + 1;
+      });
+
+      const pushSlots = (position, eligible, options = {}) => {
+        const count = positionCounts[position] || 0;
+        const { isFlex = false, primary = position, isSuperFlex = false, label } = options;
+        const displayLabel = label || position.replace('_', ' ');
+        for (let i = 0; i < count; i += 1) {
+          slots.push({
+            slotKey: `${position}${i + 1}`,
+            displayKey: position,
+            displayLabel,
+            primary,
+            eligible,
+            isFlex,
+            isSuperFlex
+          });
+        }
+      };
+
+      pushSlots('QB', ['QB']);
+      pushSlots('RB', ['RB']);
+      pushSlots('WR', ['WR']);
+      pushSlots('TE', ['TE']);
+      pushSlots('FLEX', ['RB', 'WR', 'TE'], { isFlex: true, primary: 'FLEX', label: 'FLEX' });
+      pushSlots('SUPER_FLEX', ['QB', 'RB', 'WR', 'TE'], { isFlex: true, isSuperFlex: true, primary: 'SUPER_FLEX', label: 'SUPER FLEX' });
+
+      return slots;
+    }
+  });
+})();

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -5865,3 +5865,276 @@ body[data-page="research"] .app-header {
   background: rgb(67 71 87 / 63%);
 }
 
+
+/* === League Analyzer Redesign ================================================= */
+.analyzer-page .app-header {
+  margin-bottom: 1.5rem;
+}
+
+.analyzer-header {
+  gap: 0.75rem;
+  padding: 1.1rem 1.35rem 1rem;
+}
+
+.analyzer-primary-row,
+.analyzer-secondary-row {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.analyzer-secondary-row {
+  justify-content: flex-end;
+}
+
+.analyzer-hero {
+  padding: 1.75rem 1.6rem 1.6rem;
+  margin-bottom: 1.5rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.analyzer-hero .hero-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(118,109,255,0.4) 0%, rgba(0,225,173,0.25) 100%);
+  border: 1px solid rgba(118,109,255,0.35);
+  color: var(--color-text-primary);
+}
+
+.analyzer-hero h1 {
+  font-size: clamp(1.85rem, 3vw, 2.55rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.analyzer-hero p {
+  color: var(--color-text-secondary);
+  max-width: 48rem;
+}
+
+.analyzer-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  margin: 2.5rem auto 3rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 12px;
+  width: fit-content;
+  background: rgba(18, 21, 38, 0.85);
+  border: 1px solid rgba(118, 109, 255, 0.25);
+  box-shadow: 0 18px 35px rgba(5, 7, 15, 0.45);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--color-text-primary);
+}
+
+.analyzer-loading .loading-pip {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7f6fff 0%, #4ef1c0 100%);
+  animation: analyzer-pulse 0.9s ease-in-out infinite alternate;
+}
+
+@keyframes analyzer-pulse {
+  from { transform: scale(1); opacity: 0.65; }
+  to { transform: scale(1.35); opacity: 1; }
+}
+
+.analyzer-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.analyzer-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.analyzer-summary-grid .summary-chip {
+  padding: 0.95rem 1.15rem;
+  border-radius: 14px;
+  background: rgba(15, 18, 34, 0.75);
+  border: 1px solid rgba(118, 109, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04);
+  display: grid;
+  gap: 0.35rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.analyzer-summary-grid .summary-chip:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+}
+
+.summary-chip .chip-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(199, 205, 241, 0.75);
+}
+
+.summary-chip .chip-primary {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.summary-chip .chip-meta {
+  font-size: 0.75rem;
+  color: rgba(138, 146, 192, 0.9);
+}
+
+.analyzer-top-panels,
+.analyzer-middle-panels {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.analyzer-top-panels {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.analyzer-middle-panels {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.analyzer-card {
+  padding: 1.4rem 1.35rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+}
+
+.panel-title-stack h2 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.panel-title-stack p {
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+}
+
+.toggle-pill-group {
+  display: inline-flex;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: rgba(15, 18, 34, 0.9);
+  border: 1px solid rgba(118, 109, 255, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.05);
+}
+
+.toggle-pill {
+  border: none;
+  background: transparent;
+  color: rgba(176, 185, 232, 0.8);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.95rem;
+  border-radius: 999px;
+  transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.toggle-pill.active {
+  background: linear-gradient(90deg, rgba(118,109,255,0.9), rgba(0,228,183,0.7));
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(118,109,255,0.35);
+}
+
+.toggle-pill:focus-visible {
+  outline: 2px solid rgba(118,109,255,0.45);
+  outline-offset: 2px;
+}
+
+.analyzer-card .chart-container {
+  position: relative;
+  width: 100%;
+  min-height: 340px;
+}
+
+.analyzer-radar-card .chart-container,
+.analyzer-radar-card .radar-container {
+  min-height: 420px;
+}
+
+.analyzer-card .radar-container {
+  width: 100%;
+  height: 420px;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid rgba(118,109,255,0.14);
+  background: rgba(12, 15, 30, 0.6);
+}
+
+.analyzer-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.analyzer-table th,
+.analyzer-table td {
+  padding: 0.65rem 0.9rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(118, 109, 255, 0.12);
+}
+
+.analyzer-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.7rem;
+  color: rgba(189, 198, 241, 0.75);
+  background: rgba(20, 24, 42, 0.9);
+}
+
+.analyzer-table tbody tr:hover {
+  background: rgba(118, 109, 255, 0.08);
+}
+
+.analyzer-table td {
+  color: var(--color-text-primary);
+}
+
+.analyzer-leaders-card .analyzer-table td:nth-child(5) {
+  font-weight: 600;
+  color: #4ef1c0;
+}
+
+@media (max-width: 768px) {
+  .analyzer-header {
+    padding: 1rem;
+  }
+  .analyzer-hero {
+    padding: 1.25rem 1.1rem 1.1rem;
+  }
+  .chart-container {
+    min-height: 300px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Rebuild the league analyzer layout with a research-themed header, hero, lineup toggle, standings table, and leaders panel.
- Add analyzer-specific styling for summary chips, toggle controls, chart containers, and data tables to match the refreshed UI.
- Implement a dedicated analyzer script that pulls Sleeper data for KTC and PPG metrics, drives the starter toggle, radar comparison, standings, and league leaders tables.

## Testing
- `node --check scripts/analyzer.js`


------
https://chatgpt.com/codex/tasks/task_e_68d4250629e4832e8afdd89a8f874446