### PR TITLE
Revamp league analyzer UI and add Sleeper production metrics

### DIFF
--- a/DHP2_DeployDraft1.2/analyzer/analyzer.html
+++ b/DHP2_DeployDraft1.2/analyzer/analyzer.html
@@ -1,998 +1,1260 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sleeper League KTC Infographic</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
-    <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
-    <style>
-        :root {
-            --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
-            --color-bg: #0D0E1B;
-            --color-panel-border: rgba(128, 138, 189, 0.2);
-            --color-text-primary: #EAEBF0;
-            --color-text-secondary: #9096C0;
-            --color-accent-primary: #766DFF;
-            --color-accent-primary-glow: rgba(118, 109, 255, 0.5);
-        }
-
-        body {
-            font-family: var(--font-sans);
-            background-color: var(--color-bg);
-            color: var(--color-text-primary);
-            overflow-x: hidden;
-        }
-
-        #starfield {
-            position: fixed; inset: 0; z-index: -10; pointer-events: none;
-            background: radial-gradient(ellipse at 50% 100%, #1B2735 0%, #090A0F 100%);
-        }
-
-        #stars1, #stars2, #stars3 {
-            position: absolute; left: 0; top: 0;
-            background: transparent;
-            animation: animStar linear infinite;
-        }
-
-        #stars1 { width: 1px; height: 1px; box-shadow: 1528px 425px #FFF, 1965px 1848px #FFF, 466px 588px #FFF, 1441px 1361px #FFF, 395px 1296px #FFF, 1603px 1631px #FFF, 1403px 1363px #FFF, 1010px 54px #FFF, 904px 1539px #FFF, 929px 1400px #FFF, 1370px 1286px #FFF, 612px 1109px #FFF, 1899px 1371px #FFF, 215px 873px #FFF, 1997px 882px #FFF, 283px 759px #FFF, 1675px 1005px #FFF, 145px 1973px #FFF, 1974px 1948px #FFF, 128px 1115px #FFF, 1863px 1335px #FFF, 1540px 938px #FFF, 1739px 491px #FFF, 1898px 1397px #FFF, 706px 1264px #FFF, 1505px 1162px #FFF, 200px 1889px #FFF, 1044px 1230px #FFF, 315px 1227px #FFF, 625px 217px #FFF, 1813px 1135px #FFF, 287px 791px #FFF, 1131px 816px #FFF, 845px 87px #FFF, 272px 94px #FFF, 1341px 1194px #FFF, 1547px 893px #FFF, 1460px 1971px #FFF, 655px 1052px #FFF, 1178px 815px #FFF, 1643px 1785px #FFF, 1172px 277px #FFF, 1486px 280px #FFF, 134px 1224px #FFF, 338px 213px #FFF, 814px 1844px #FFF, 1207px 806px #FFF, 14px 526px #FFF, 957px 455px #7300ff, 518px 864px #7300ff, 321px 438px #7300ff, 1226px 1328px #FFF, 784px 1010px #FF0266, 1052px 1568px #FF0266, 350px 478px #FF0266; animation-duration: 450s; }
-        #stars2 { width: 2px; height: 2px; box-shadow: 444px 26px #FFF, 644px 550px #FFF, 428px 426px #FFF, 12px 1913px #FFF, 680px 225px #FFF, 1346px 474px #FFF, 6px 1693px #FFF, 1555px 996px #FFF, 579px 1620px #FFF, 364px 1911px #FFF, 282px 1788px #FFF, 280px 337px #FFF, 1880px 1547px #FF0266, 1531px 1567px #FF0266, 193px 1099px #FF0266, 1540px 17px #FF0266, 1774px 292px #FF0266, 183px 775px #FF0266, 214px 107px #FFF, 695px 88px #FFF, 490px 1209px #FFF, 1374px 560px #FFF, 752px 1759px #FFF, 1985px 866px #FFF, 609px 310px #FFF, 86px 1036px #FFF, 638px 191px #FFF, 1635px 626px #FFF, 78px 998px #FFF, 1189px 1345px #FFF, 48px 1383px #FFF, 1981px 345px #FFF, 1993px 1838px #FFF, 717px 1540px #FFF, 287px 673px #FFF, 1821px 1665px #FFF, 686px 600px #FFF, 572px 777px #FFF, 932px 537px #FFF, 1808px 1538px #FFF, 1563px 305px #FFF, 1771px 1974px #FFF, 393px 1768px #FFF, 368px 1426px #FFF, 434px 779px #FFF, 566px 1370px #FFF, 261px 791px #FFF, 141px 434px #1ACDD1; animation-duration: 400s; }
-        #stars3 { width: 3px; height: 3px; box-shadow: 1208px 1620px #FF0070, 576px 1883px #FFF, 1810px 913px #FFF, 87px 1117px #FFF, 1076px 1851px #FFF, 859px 264px #FFF, 1469px 1346px #FFF, 1651px 1493px #FFF, 767px 822px #FFF, 359px 967px #FFF, 1009px 808px #FF0070, 100px 1656px #7300ff, 1365px 1511px #7300ff, 429px 1279px #7300ff, 1381px 1850px #E86439, 1896px 1999px #E86439, 236px 718px #7300ff, 39px 1731px #7300ff, 562px 1084px #7300ff, 1067px 1431px #FF0266, 1362px 1575px #FF0266, 953px 1860px #FF0266, 1498px 499px #FF0266, 1055px 885px #FFF, 1824px 1334px #FFF, 519px 1319px #FFF, 1716px 1538px #FFF, 1305px 524px #FFF, 808px 1972px #FFF, 426px 649px #FFF, 882px 1530px #FFF, 623px 557px #FFF, 129px 1750px #FF0070; animation-duration: 350s; }
-        
-        @keyframes animStar { from { transform: translateY(0px); } to { transform: translateY(-2000px); } }
-
-        .glass-panel {
-            background-color: rgba(13, 14, 35, 0.21);
-            background-image: linear-gradient(rgba(255,255,255, 0.03), rgba(255,255,255, 0.03));
-            backdrop-filter: blur(6px) saturate(120%) brightness(120%);
-            border: 1px solid rgba(128, 138, 189, 0.2);
-            border-radius: 10px;
-            box-shadow: inset 0 0 0 1px rgba(255,255,255, 0.05), 
-                        inset 0 0 0 2px rgba(200,200,200, 0.025), 
-                        0 10px 26px rgba(0,0,0, .22);
-        }
-        
-        h1, h2, h3 {
-            font-family: var(--font-sans);
-            color: var(--color-text-primary);
-            text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
-        }
-        h1 { font-weight: 700; }
-        h2 { font-weight: 500; }
-        h3 { font-weight: 500; }
-        
-        .chart-container {
-            position: relative;
-            height: 450px;
-            width: 100%;
-        }
-
-        .power-grid-item h3 {
-            font-size: 1rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: .8px;
-            color: var(--color-text-primary);
-            text-align: center;
-            padding: 0.2rem 0;
-            margin-bottom: 0.5rem;
-            position: relative;
-            border: 1px solid var(--color-panel-border);
-            border-radius: 5px;
-            backdrop-filter: saturate(114%) blur(1px);
-            overflow: hidden;
-        }
-
-        .power-grid-item h3::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            border-radius: inherit;
-            pointer-events: none;
-            background-color: rgba(20, 28, 58, 0.15);
-            background-image: linear-gradient(rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 35%);
-        }
-
-
-        /* Fix for browser autofill styles */
-        input:-webkit-autofill,
-        input:-webkit-autofill:hover,
-        input:-webkit-autofill:focus,
-        input:-webkit-autofill:active {
-            -webkit-box-shadow: 0 0 0 30px #0D0E1B inset !important; /* Match body bg */
-            -webkit-text-fill-color: #c4c8ea !important;
-            transition: background-color 5000s ease-in-out 0s;
-            caret-color: #c4c8ea;
-        }
-
-        #usernameInput, #leagueSelect {
-            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
-            border: 1px solid var(--color-panel-border);
-            border-radius: 8px;
-            backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-            color: #c4c8ea;
-            transition: all 0.2s ease;
-        }
-
-        #usernameInput:focus, #leagueSelect:focus {
-            outline: none;
-            border-color: var(--color-accent-primary);
-            box-shadow: 0 0 8px var(--color-accent-primary-glow);
-        }
-
-    </style>
+  <meta charset="utf-8" />
+  <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+  <title>League Analyzer • Dynasty Hub</title>
+  <link href="https://fonts.googleapis.com" rel="preconnect" />
+  <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&amp;display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&amp;display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet" />
+  <link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+  <meta content="#0D0E1B" name="theme-color" />
+  <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+  <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body data-page="analyzer" class="p-2 sm:p-4">
-    <!-- Replaced Background: Starfield -->
-    <div aria-hidden="true" id="starfield">
-        <div id="stars1"></div>
-        <div id="stars2"></div>
-        <div id="stars3"></div>
+  <div aria-hidden="true" id="starfield">
+    <div id="stars"></div>
+    <div id="stars1"></div>
+    <div id="stars2"></div>
+    <div id="stars3"></div>
+  </div>
+  <div id="noise-overlay"></div>
+  <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+      <header class="app-header glass-panel">
+        <div class="header-row">
+          <div class="menu-container">
+            <button id="menu-button" class="menu-button" aria-label="Toggle navigation">
+              <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+              </svg>
+            </button>
+            <div id="dropdown-menu" class="dropdown-menu hidden">
+              <a href="../index.html">
+                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                <span>Home</span>
+              </a>
+              <a href="#" id="menu-rosters">
+                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                <span>Rosters</span>
+              </a>
+              <a href="#" id="menu-ownership">
+                <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                <span>Ownership</span>
+              </a>
+              <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+              </a>
+              <a href="#" id="menu-analyzer" class="active">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+              </a>
+            </div>
+          </div>
+          <div class="username-area">
+            <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle" />
+          </div>
+          <div class="custom-select-wrapper">
+            <select id="leagueSelect" disabled>
+              <option>Select a league...</option>
+            </select>
+          </div>
+        </div>
+      </header>
     </div>
-    <div id="noise-overlay"></div>
-    <div class="relative z-10 content-wrapper">
-        <div id="header-container">
-            <header class="app-header glass-panel">
-                <div class="header-row">
-                    <div class="menu-container">
-                        <button id="menu-button" class="menu-button">
-                            <svg viewBox="0 0 100 80" width="20" height="20">
-                                <rect width="100" height="15"></rect>
-                                <rect y="30" width="100" height="15"></rect>
-                                <rect y="60" width="100" height="15"></rect>
-                            </svg>
-                        </button>
-                        <div id="dropdown-menu" class="dropdown-menu hidden">
-                            <a href="../">
-                                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-                                <span>Home</span>
-                            </a>
-                            <a href="#" id="menu-rosters">
-                                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-                                <span>Rosters</span>
-                            </a>
-                            <a href="#" id="menu-ownership">
-                                <i class="fa-solid fa-percent" aria-hidden="true"></i>
-                                <span>Ownership</span>
-                            </a>
-                            <a href="#" id="menu-research">
-                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                                <span>Research</span>
-                            </a>
-                            <a href="#" id="menu-analyzer">
-                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                                <span>League Analyzer</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="username-area">
-                        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-                    </div>
-                    <div class="custom-select-wrapper">
-                        <select id="leagueSelect" disabled>
-                            <option>Select a league...</option>
-                        </select>
-                    </div>
-                </div>
+    <main class="container mx-auto analyzer-main" id="content">
+      <section class="analyzer-hero glass-panel" aria-labelledby="analyzer-title">
+        <div class="analyzer-hero-intro">
+          <div class="analyzer-pill">Dynasty Hub</div>
+          <h1 id="analyzer-title">League Analyzer</h1>
+          <p id="leagueMeta" class="analyzer-hero-meta">KTC Value &amp; production insights powered by Sleeper</p>
+        </div>
+        <div class="analyzer-hero-context" id="leagueContext"></div>
+      </section>
+
+      <section id="summaryStats" class="analyzer-summary-grid hidden" aria-label="Team summary highlights"></section>
+
+      <div id="loading" class="hidden analyzer-loading glass-panel">
+        <p class="text-lg md:text-xl">Analyzing cosmic data streams...</p>
+      </div>
+
+      <section id="infographicContent" class="hidden space-y-6" aria-live="polite">
+        <section class="analyzer-panels-grid">
+          <article class="glass-panel analyzer-panel" aria-label="Starting lineup metrics">
+            <header class="analyzer-panel-header">
+              <div>
+                <h2>Starting Lineup Output</h2>
+                <p class="analyzer-panel-subtitle" id="starterChartSubtitle">KTC valuation across starter slots</p>
+              </div>
+              <div class="analyzer-toggle" role="group" aria-label="Starter metric mode">
+                <button type="button" class="analyzer-toggle-button active" data-starter-mode="ktc">Value</button>
+                <button type="button" class="analyzer-toggle-button" data-starter-mode="ppg">PPG</button>
+              </div>
             </header>
-        </div>
-        <main class="container mx-auto" id="content">
-            <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
-                <!-- Page Header -->
-                <header class="text-center space-y-2">
-                    <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
-                    <p class="text-md text-gray-400">KTC Team Value Analysis</p>
-                </header>
-
-                <!-- Summary Stats -->
-                <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
-            <!-- Summary boxes injected here -->
+            <div class="chart-container">
+              <canvas id="startersValueChart" aria-label="Starting lineup comparison chart" role="img"></canvas>
+            </div>
+          </article>
+          <article class="glass-panel analyzer-panel" aria-label="Overall roster valuation">
+            <header class="analyzer-panel-header">
+              <div>
+                <h2>Overall Team Value</h2>
+                <p class="analyzer-panel-subtitle">KTC by roster construction</p>
+              </div>
+            </header>
+            <div class="chart-container">
+              <canvas id="overallValueChart" aria-label="Overall team value chart" role="img"></canvas>
+            </div>
+          </article>
         </section>
 
-        <!-- Loading Indicator -->
-        <div id="loading" class="hidden text-center py-8">
-            <p class="text-2xl animate-pulse">Analyzing cosmic data streams...</p>
-        </div>
-
-        <!-- Main Content -->
-        <section id="infographicContent" class="hidden space-y-6">
-            <!-- Top Level Charts -->
-            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Starting Lineup Value</h2>
-                    <div class="chart-container">
-                        <canvas id="startersValueChart"></canvas>
-                    </div>
-                </div>
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Overall Team Value</h2>
-                    <div class="chart-container">
-                        <canvas id="overallValueChart"></canvas>
-                    </div>
-                </div>
-            </section>
-            
-            <!-- Radar Chart -->
-            <section class="glass-panel p-2">
-                <h2 class="text-2xl text-center mb-4">Positional Strength</h2>
-                <div class="chart-container">
-                    <canvas id="radarChart"></canvas>
-                </div>
-            </section>
-
-            <!-- Detailed Starter Rankings -->
-            <section class="glass-panel p-6">
-                <h2 class="text-2xl text-center mb-6">Starting Position Power Grid</h2>
-                <div id="starterRankingsGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-                    <!-- Grid items will be injected here by JavaScript -->
-                </div>
-            </section>
+        <section class="glass-panel analyzer-panel" aria-label="Positional strength radar">
+          <header class="analyzer-panel-header">
+            <div>
+              <h2>Positional Strength vs League</h2>
+              <p class="analyzer-panel-subtitle">Top two players at each position</p>
+            </div>
+          </header>
+          <div class="chart-container">
+            <canvas id="radarChart" aria-label="Positional radar comparison" role="img"></canvas>
+          </div>
         </section>
-    </div>
-        </main>
-    </div>
 
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const params = new URLSearchParams(window.location.search);
-            const username = params.get('username');
-            const leagueId = params.get('leagueId');
-
-            // --- DOM Elements ---
-            const usernameInput = document.getElementById('usernameInput');
-            const leagueSelect = document.getElementById('leagueSelect');
-            const loadingIndicator = document.getElementById('loading');
-            const infographicContent = document.getElementById('infographicContent');
-            const starterRankingsGrid = document.getElementById('starterRankingsGrid');
-            const summaryStats = document.getElementById('summaryStats');
-
-
-            // --- Chart instances ---
-            let overallChart, startersChart, radarChart;
-
-            // --- State ---
-            let state = {
-                userId: null,
-                leagues: [],
-                players: {},
-                ktcOneQb: {},
-                ktcSflx: {},
-                currentLeagueId: null,
-                isSuperflex: false,
-                cache: {}
-            };
-
-            const POS_COLORS = {
-                QB: 'rgba(255, 58, 117, 0.8)',
-                RB: 'rgba(0, 235, 199, 0.8)',
-                WR: 'rgba(88, 167, 255, 0.8)',
-                TE: 'rgba(180, 105, 255, 0.8)',
-                FLEX: 'rgba(255, 127, 80, 0.8)', // Coral
-                SUPER_FLEX: 'rgba(220, 220, 220, 0.8)', // Silver
-                Picks: 'rgba(255, 199, 0, 0.8)'
-            };
-
-
-            // --- Event Listeners ---
-            usernameInput.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') {
-                    handleFetchData();
-                }
-            });
-            leagueSelect.addEventListener('change', () => {
-                if (leagueSelect.value) {
-                    analyzeLeague(leagueSelect.value);
-                }
-            });
-
-            if (username) {
-                usernameInput.value = username;
-                handleFetchData();
-            }
-
-            async function handleFetchData() {
-                const username = usernameInput.value.trim();
-                if (!username) {
-                    alert('Please enter a Sleeper username.');
-                    return;
-                }
-
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                summaryStats.classList.add('hidden');
-
-                try {
-                    // Fetch all initial data concurrently
-                    await Promise.all([
-                        fetchSleeperPlayers(),
-                        fetchKTCData()
-                    ]);
-                    
-                    await fetchUserAndLeagues(username);
-
-                    if (state.leagues.length > 0) {
-                        if (leagueId) {
-                            const leagueExists = state.leagues.some(l => l.league_id === leagueId);
-                            if (leagueExists) {
-                                leagueSelect.value = leagueId;
-                                await analyzeLeague(leagueId);
-                            } else {
-                                alert('The specified league was not found for this user.');
-                                setLoading(false);
-                            }
-                        } else {
-                            // Auto-select and analyze the first league
-                            leagueSelect.selectedIndex = 1;
-                            await analyzeLeague(state.leagues[0].league_id);
-                        }
-                    }
-                } catch (error) {
-                    console.error('Error fetching data:', error);
-                    alert(`An error occurred: ${error.message}`);
-                } finally {
-                    setLoading(false);
-                }
-            }
-
-            // --- Data Fetching ---
-            async function fetchWithCache(url) {
-                if (state.cache[url]) return state.cache[url];
-                const response = await fetch(url);
-                if (!response.ok) throw new Error(`API request failed: ${response.statusText}`);
-                const data = await response.json();
-                state.cache[url] = data;
-                return data;
-            }
-
-            async function fetchSleeperPlayers() {
-                if (Object.keys(state.players).length > 0) return;
-                state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
-            }
-
-            async function fetchKTCData() {
-                if (Object.keys(state.ktcOneQb).length > 0) return;
-                const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
-                try {
-                    const [oneQbCsv, sflxCsv] = await Promise.all([
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch 1QB KTC data: ' + res.statusText);
-                            return res.text();
-                        }),
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch SFLX KTC data: ' + res.statusText);
-                            return res.text();
-                        })
-                    ]);
-                    state.ktcOneQb = parseSheetData(oneQbCsv);
-                    state.ktcSflx = parseSheetData(sflxCsv);
-                } catch (error) {
-                     console.error("KTC Fetch Error:", error);
-                     throw new Error("Could not retrieve KTC valuation data. The proxy service may be down. Please try again later.");
-                }
-            }
-            
-            function parseSheetData(csvText) {
-                const dataMap = {};
-                const lines = csvText.split(/\r?\n/).filter(line => line.trim().length > 0);
-                if (lines.length === 0) return dataMap;
-
-                const parseLine = (line) => {
-                    const result = [];
-                    let current = '';
-                    let inQuotes = false;
-                    const sanitized = line.replace(/\r$/, '');
-
-                    for (let i = 0; i < sanitized.length; i++) {
-                        const char = sanitized[i];
-                        if (inQuotes) {
-                            if (char === '"') {
-                                if (sanitized[i + 1] === '"') {
-                                    current += '"';
-                                    i++;
-                                } else {
-                                    inQuotes = false;
-                                }
-                            } else {
-                                current += char;
-                            }
-                        } else if (char === '"') {
-                            inQuotes = true;
-                        } else if (char === ',') {
-                            result.push(current.trim());
-                            current = '';
-                        } else {
-                            current += char;
-                        }
-                    }
-                    result.push(current.trim());
-                    return result;
-                };
-
-                const normalize = (header) => header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
-                const headers = parseLine(lines[0]).map(cell => cell.trim());
-                const headerIndex = new Map();
-                headers.forEach((header, idx) => {
-                    headerIndex.set(normalize(header), idx);
-                });
-
-                const getValue = (columns, names) => {
-                    const keys = Array.isArray(names) ? names : [names];
-                    for (const name of keys) {
-                        const idx = headerIndex.get(normalize(name));
-                        if (idx !== undefined && columns[idx] !== undefined) {
-                            return columns[idx].trim();
-                        }
-                    }
-                    return '';
-                };
-
-                const toInt = (value) => {
-                    const num = parseInt(value, 10);
-                    return Number.isNaN(num) ? null : num;
-                };
-
-                lines.slice(1).forEach(line => {
-                    const columns = parseLine(line);
-                    if (!columns.length) return;
-
-                    const pos = getValue(columns, 'POS');
-                    const sleeperId = getValue(columns, 'SLPR_ID');
-                    const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
-
-                    if (pos === 'RDP') {
-                        const pickName = getValue(columns, 'PLAYER NAME');
-                        if (pickName) {
-                            dataMap[pickName] = { ktc: ktcValue };
-                        }
-                        return;
-                    }
-
-                    if (!sleeperId || sleeperId === 'NA') return;
-
-                    dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
-                });
-
-                return dataMap;
-            }
-
-            async function fetchUserAndLeagues(username) {
-                const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
-                if (!user || !user.user_id) throw new Error('Sleeper user not found.');
-                state.userId = user.user_id;
-
-                const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${new Date().getFullYear()}`);
-                if (!leagues || leagues.length === 0) throw new Error('No active leagues found for this user in the current season.');
-                state.leagues = leagues.sort((a,b) => a.name.localeCompare(b.name));
-
-                populateLeagueSelect(state.leagues);
-            }
-
-            async function analyzeLeague(leagueId) {
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                state.currentLeagueId = leagueId;
-
-                const leagueInfo = state.leagues.find(l => l.league_id === leagueId);
-                const qbSlots = leagueInfo.roster_positions.filter(p => p === 'QB').length;
-                const superflexSlots = leagueInfo.roster_positions.filter(p => p === 'SUPER_FLEX').length;
-                state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
-
-                const [rosters, users, tradedPicks] = await Promise.all([
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`)
-                ]);
-
-                const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
-                
-                infographicContent.classList.remove('hidden');
-                summaryStats.classList.remove('hidden');
-                
-                renderSummaryStats(teams);
-                renderCharts(teams);
-                renderRadarChart(teams);
-                renderStarterGrid(teams, leagueInfo);
-
-                setLoading(false);
-            }
-
-            function processLeagueData(rosters, users, tradedPicks, leagueInfo) {
-                const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
-
-                return rosters.map(roster => {
-                    const owner = userMap[roster.owner_id];
-                    const teamName = owner?.display_name || `Team ${roster.roster_id}`;
-                    
-                    let topPlayer = { name: 'N/A', ktc: 0 };
-                    const allPlayers = (roster.players || []).map(pId => {
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        if (ktc > topPlayer.ktc) {
-                            topPlayer = { name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown', ktc };
-                        }
-                        return { id: pId, pos: playerInfo?.position, ktc };
-                    }).sort((a,b) => b.ktc - a.ktc);
-
-                    const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
-                    allPlayers.forEach(p => {
-                        if (overallPositional.hasOwnProperty(p.pos)) {
-                            overallPositional[p.pos] += p.ktc;
-                        }
-                    });
-                    
-                    getOwnedPicks(roster.roster_id, rosters, tradedPicks, leagueInfo).forEach(p => {
-                        overallPositional.Picks += getKtcValue(p.label);
-                    });
-
-                    const startersPositional = { QB: 0, RB: 0, WR: 0, TE: 0, FLEX: 0, 'SUPER_FLEX': 0 };
-                    const startersPlayerDetails = { QB: [], RB: [], WR: [], TE: [], FLEX: [], 'SUPER_FLEX': [] };
-                    const startersValueByPosition = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                    const starterIds = roster.starters || [];
-                    const rosterPositions = leagueInfo.roster_positions;
-                    starterIds.forEach((pId, index) => {
-                        const slot = rosterPositions[index];
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        
-                        // For stacked bar chart
-                        if (startersPositional.hasOwnProperty(slot)) {
-                            startersPositional[slot] += ktc;
-                            startersPlayerDetails[slot].push({
-                                name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown',
-                                ktc: ktc
-                            });
-                        }
-
-                        // For summary rank calculation
-                        if (playerInfo && startersValueByPosition.hasOwnProperty(playerInfo.position)) {
-                            startersValueByPosition[playerInfo.position] += ktc;
-                        }
-                    });
-                    
-                    const totalValue = Object.values(overallPositional).reduce((a, b) => a + b, 0);
-
-                    return {
-                        teamName,
-                        totalValue,
-                        startersValue: Object.values(startersPositional).reduce((a,b) => a+b, 0),
-                        overallPositional,
-                        startersPositional,
-                        startersPlayerDetails,
-                        startersValueByPosition,
-                        roster,
-                        topPlayer,
-                        allPlayers,
-                        isUserTeam: roster.owner_id === state.userId
-                    };
-                }).sort((a,b) => b.totalValue - a.totalValue);
-            }
-
-            function getOwnedPicks(rosterId, allRosters, tradedPicks, leagueInfo) {
-                const currentYear = new Date().getFullYear();
-                const all_picks = [];
-
-                // 1. Generate all original picks for every team for the next 4 years
-                for (const r of allRosters) {
-                    for (let i = 1; i <= 4; i++) {
-                        const season = currentYear + i;
-                        for (let round = 1; round <= leagueInfo.settings.draft_rounds; round++) {
-                            all_picks.push({
-                                season: season.toString(),
-                                round: round,
-                                roster_id: r.roster_id, // Original owner
-                                owner_id: r.roster_id    // Current owner (by default)
-                            });
-                        }
-                    }
-                }
-
-                // 2. Account for trades
-                tradedPicks.forEach(trade => {
-                    const pickIndex = all_picks.findIndex(p =>
-                        p.season === trade.season &&
-                        p.round === trade.round &&
-                        p.roster_id === trade.roster_id
-                    );
-                    if (pickIndex !== -1) {
-                        all_picks[pickIndex].owner_id = trade.owner_id;
-                    }
-                });
-
-                // 3. Filter for picks owned by the current roster
-                return all_picks
-                    .filter(p => p.owner_id === rosterId)
-                    .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
-                    .map(p => ({ ...p, label: `${p.season} Mid ${ordinal(p.round)}` }));
-            }
-
-            // --- UI Rendering ---
-            function renderSummaryStats(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) {
-                    summaryStats.classList.add('hidden');
-                    return;
-                }
-
-                const sortedByStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                
-                const totalRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-                const starterRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-
-                const positionsToRank = ['QB', 'RB', 'WR', 'TE'];
-                const positionalRanks = {};
-                positionsToRank.forEach(pos => {
-                    const sorted = [...teams].sort((a,b) => b.startersValueByPosition[pos] - a.startersValueByPosition[pos]);
-                    positionalRanks[pos] = sorted.findIndex(t => t.isUserTeam) + 1;
-                });
-
-                summaryStats.innerHTML = `
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Overall Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(totalRank, teams.length)}">${totalRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters KTC</p>
-                        <p class="text-lg font-bold">${userTeam.startersValue.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(starterRank, teams.length)}">${starterRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Top Player</p>
-                        <p class="text-sm font-bold truncate">${userTeam.topPlayer.name}</p>
-                        <p class="text-[10px] text-purple-400">${userTeam.topPlayer.ktc.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">QB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.QB, teams.length)}">${positionalRanks.QB}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">RB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.RB, teams.length)}">${positionalRanks.RB}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">WR Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.WR, teams.length)}">${positionalRanks.WR}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">TE Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.TE, teams.length)}">${positionalRanks.TE}/${teams.length}</p>
-                    </div>
-                `;
-            }
-            
-            function renderCharts(teams) {
-                const labels = teams.map(t => {
-                    const name = t.teamName;
-                    return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                });
-
-                // Overall Chart
-                const overallDatasets = Object.keys(teams[0].overallPositional).map(pos => ({
-                    label: pos,
-                    data: teams.map(t => t.overallPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                if(overallChart) overallChart.destroy();
-                const overallMaxKtc = Math.max(...teams.map(t => t.totalValue));
-                overallChart = new Chart(document.getElementById('overallValueChart'), {
-                    type: 'bar',
-                    data: { labels, datasets: overallDatasets },
-                    options: chartOptions(null, overallMaxKtc)
-                });
-
-                // Starters Chart
-                const sortedStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                const startersLabels = sortedStarters.map(t => t.teamName);
-                const startersDatasets = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].map(pos => ({
-                    label: pos,
-                    data: sortedStarters.map(t => t.startersPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                
-                const startersMaxKtc = Math.max(...sortedStarters.map(t => t.startersValue));
-
-                if(startersChart) startersChart.destroy();
-                startersChart = new Chart(document.getElementById('startersValueChart'), {
-                    type: 'bar',
-                    data: {
-                        labels: sortedStarters.map(t => {
-                            const name = t.teamName;
-                            return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                        }),
-                        datasets: startersDatasets
-                    },
-                    options: chartOptions(sortedStarters, startersMaxKtc) // Pass sorted teams and max value
-                });
-            }
-
-            function renderRadarChart(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) return;
-
-                const leagueAverages = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const userValues = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const positions = ['QB', 'RB', 'WR', 'TE'];
-
-                positions.forEach(pos => {
-                    let totalLeagueKTC = 0;
-                    teams.forEach(team => {
-                        const topTwoPlayers = team.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                        totalLeagueKTC += topTwoPlayers.reduce((sum, player) => sum + player.ktc, 0);
-                    });
-                    leagueAverages[pos] = totalLeagueKTC / teams.length;
-
-                    const userTopTwo = userTeam.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                    userValues[pos] = userTopTwo.reduce((sum, player) => sum + player.ktc, 0);
-                });
-                
-                if(radarChart) radarChart.destroy();
-                radarChart = new Chart(document.getElementById('radarChart'), {
-                    type: 'radar',
-                    data: {
-                        labels: positions,
-                        datasets: [
-                            {
-                                label: 'Your Team (Top 2)',
-                                data: Object.values(userValues),
-                                fill: true,
-                                backgroundColor: 'rgba(118, 109, 255, 0.4)',
-                                borderColor: 'rgba(118, 109, 255, 1)',
-                                pointBackgroundColor: 'rgba(118, 109, 255, 1)',
-                                pointBorderColor: '#fff',
-                            },
-                            {
-                                label: 'League Average (Top 2)',
-                                data: Object.values(leagueAverages),
-                                fill: true,
-                                backgroundColor: 'rgba(66, 194, 255, 0.4)',
-                                borderColor: 'rgba(66, 194, 255, 1)',
-                                pointBackgroundColor: 'rgba(66, 194, 255, 1)',
-                                pointBorderColor: '#fff',
-                            }
-                        ]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        elements: {
-                            line: {
-                                borderWidth: 3
-                            }
-                        },
-                        scales: {
-                            r: {
-                                angleLines: { color: 'rgba(255, 255, 255, 0.2)' },
-                                grid: { color: 'rgba(255, 255, 255, 0.2)' },
-                                pointLabels: {
-                                    font: { size: 14, family: "'Orbitron', sans-serif" },
-                                    color: '#EAEBF0'
-                                },
-                                ticks: {
-                                    color: '#EAEBF0',
-                                    backdropColor: 'rgba(0,0,0,0.5)',
-                                    font: { family: "'Roboto', sans-serif" }
-                                }
-                            }
-                        },
-                        plugins: {
-                             legend: {
-                                position: 'top',
-                                labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                            }
-                        }
-                    }
-                });
-            }
-
-            function renderStarterGrid(teams, leagueInfo) {
-                starterRankingsGrid.innerHTML = '';
-
-                const starterPositions = {};
-                leagueInfo.roster_positions.forEach(pos => {
-                    if (['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].includes(pos)) {
-                        starterPositions[pos] = (starterPositions[pos] || 0) + 1;
-                    }
-                });
-
-                Object.entries(starterPositions).forEach(([slotPosition, count]) => {
-                    for (let i = 0; i < count; i++) {
-                        const slotIndex = i + 1;
-                        const slotData = [];
-
-                        teams.forEach(team => {
-                            const starters = team.roster.starters || [];
-                            const positions = leagueInfo.roster_positions;
-                            let playerFound = false;
-                            let currentSlotCount = 0;
-
-                            for (let j = 0; j < starters.length; j++) {
-                                if (positions[j] === slotPosition) {
-                                    currentSlotCount++;
-                                    if (currentSlotCount === slotIndex) {
-                                        const playerId = starters[j];
-                                        const playerInfo = state.players[playerId];
-                                        const ktcValue = getKtcValue(playerId);
-                                        slotData.push({
-                                            teamName: team.teamName,
-                                            playerName: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name} ${playerInfo.last_name}` : 'Empty Slot',
-                                            ktcValue: ktcValue,
-                                        });
-                                        playerFound = true;
-                                        break;
-                                    }
-                                }
-                            }
-                             if (!playerFound) {
-                                slotData.push({ teamName: team.teamName, playerName: 'Empty Slot', ktcValue: 0 });
-                            }
-                        });
-
-                        slotData.sort((a, b) => b.ktcValue - a.ktcValue);
-
-                        const gridItem = document.createElement('div');
-                        gridItem.className = 'glass-panel p-3';
-
-                        let content = `<h3 class="text-lg font-bold text-center mb-2">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
-                        slotData.forEach((data, index) => {
-                            const rank = index + 1;
-                            const color = getRankColor(rank, teams.length);
-                            content += `
-                                <li class="flex justify-between items-center text-xs py-0.5 border-b border-gray-800/50 gap-2">
-                                    <div class="flex items-center gap-2 w-3/5 min-w-0">
-                                        <span class="font-bold w-6 flex-shrink-0" style="color: ${color};">${rank}.</span>
-                                        <span class="truncate">${data.teamName}</span>
-                                    </div>
-                                    <div class="text-right flex-shrink-0 w-2/5">
-                                        <span class="font-semibold" style="color: ${color};">${data.ktcValue.toLocaleString()}</span>
-                                        <p class="text-xs text-gray-500 truncate">${data.playerName}</p>
-                                    </div>
-                                </li>
-                            `;
-                        });
-                        content += '</ul>';
-                        gridItem.innerHTML = content;
-                        starterRankingsGrid.appendChild(gridItem);
-                    }
-                });
-            }
-
-            // --- Charting ---
-            function chartOptions(teamsDataForTooltip = null, maxKtc = 0) {
-                const tooltipOptions = {
-                     backgroundColor: 'rgba(13, 14, 27, 0.9)',
-                     titleFont: { family: "'Orbitron', sans-serif", size: 16 },
-                     bodyFont: { family: "'Roboto', sans-serif", size: 12 },
-                     footerFont: { family: "'Roboto', sans-serif", weight: 'bold' },
-                     borderColor: 'rgba(118, 109, 255, 0.5)',
-                     borderWidth: 1,
-                     padding: 10,
-                     callbacks: {}
-                };
-
-                if (teamsDataForTooltip) {
-                    tooltipOptions.callbacks.footer = (tooltipItems) => {
-                        const teamIndex = tooltipItems[0].dataIndex;
-                        const positionLabel = tooltipItems[0].dataset.label;
-                        const teamData = teamsDataForTooltip[teamIndex];
-                        
-                        if (teamData && teamData.startersPlayerDetails && teamData.startersPlayerDetails[positionLabel]) {
-                            const players = teamData.startersPlayerDetails[positionLabel];
-                            return players
-                                .sort((a, b) => b.ktc - a.ktc)
-                                .slice(0, 3)
-                                .map(p => `${p.name}: ${p.ktc.toLocaleString()}`)
-                                .join('\n');
-                        }
-                        return '';
-                    };
-                }
-
-                return {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    indexAxis: 'y',
-                    layout: {
-                        padding: {
-                            left: 0,
-                            right: 5 
-                        }
-                    },
-                    scales: {
-                        x: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif"
-                                 },
-                                 maxRotation: 45,
-                                 minRotation: 45,
-                            },
-                            grid: { color: 'rgba(255, 255, 255, 0.1)' },
-                            max: Math.ceil(maxKtc / 10000) * 10000,
-                        },
-                        y: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif",
-                                    size: 10
-                                 },
-                                 callback: function(value, index, values) {
-                                    const label = this.getLabelForValue(value);
-                                    // The label is already truncated before being passed to the chart data
-                                    return label;
-                                }
-                            },
-                            grid: { display: false }
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            position: 'bottom',
-                            labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                        },
-                        tooltip: tooltipOptions
-                    }
-                };
-            }
-            
-            // --- KTC & Formatting Helpers ---
-            function getKtcValue(id) {
-                const ktcSource = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
-                return ktcSource[id]?.ktc || 0;
-            }
-
-            function ordinal(i) {
-                const j = i % 10, k = i % 100;
-                if (j === 1 && k !== 11) return i + "st";
-                if (j === 2 && k !== 12) return i + "nd";
-                if (j === 3 && k !== 13) return i + "rd";
-                return i + "th";
-            }
-
-            function getRankColor(rank, total) {
-                const percentile = (total - rank + 1) / total;
-                if (percentile >= 0.8) return '#00EBC7'; // Top 20%
-                if (percentile >= 0.6) return '#58A7FF';
-                if (percentile >= 0.4) return '#EAEBF0';
-                if (percentile >= 0.2) return '#FF7F50';
-                return '#FF3A75'; // Bottom 20%
-            }
-
-            // --- UI Helpers ---
-            function populateLeagueSelect(leagues) {
-                leagueSelect.innerHTML = '<option value="">Select a league...</option>';
-                leagues.forEach(league => {
-                    const option = document.createElement('option');
-                    option.value = league.league_id;
-                    option.textContent = league.name;
-                    leagueSelect.appendChild(option);
-                });
-                leagueSelect.disabled = false;
-            }
-
-            function setLoading(isLoading) {
-                if (isLoading) {
-                    loadingIndicator.classList.remove('hidden');
-                } else {
-                    loadingIndicator.classList.add('hidden');
-                }
-            }
+        <section class="glass-panel analyzer-panel" aria-label="League standings">
+          <header class="analyzer-panel-header">
+            <div>
+              <h2>League Standings</h2>
+              <p class="analyzer-panel-subtitle">Record · Points For · Points Against</p>
+            </div>
+          </header>
+          <div class="analyzer-table-wrapper">
+            <table class="analyzer-table" aria-describedby="standingsCaption">
+              <caption id="standingsCaption" class="sr-only">Ordered league standings with points for and against</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Rank</th>
+                  <th scope="col">Team</th>
+                  <th scope="col">Record</th>
+                  <th scope="col">PF</th>
+                  <th scope="col">PA</th>
+                </tr>
+              </thead>
+              <tbody id="standingsTableBody"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="glass-panel analyzer-panel" aria-label="League leaderboards">
+          <header class="analyzer-panel-header">
+            <div>
+              <h2>League Leaders</h2>
+              <p class="analyzer-panel-subtitle">Top 10 scorers by position (Sleeper fantasy points)</p>
+            </div>
+            <nav class="analyzer-leaderboard-tabs" aria-label="Leaderboard positions">
+              <button type="button" class="leaderboard-tab active" data-position-filter="QB">QB</button>
+              <button type="button" class="leaderboard-tab" data-position-filter="RB">RB</button>
+              <button type="button" class="leaderboard-tab" data-position-filter="WR">WR</button>
+              <button type="button" class="leaderboard-tab" data-position-filter="TE">TE</button>
+            </nav>
+          </header>
+          <div class="analyzer-table-wrapper">
+            <table class="analyzer-table" aria-describedby="leadersCaption">
+              <caption id="leadersCaption" class="sr-only">Top performers and owners for the selected position</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Rank</th>
+                  <th scope="col">Player</th>
+                  <th scope="col">Owner</th>
+                  <th scope="col">FPTS</th>
+                  <th scope="col">PPG</th>
+                  <th scope="col">G</th>
+                </tr>
+              </thead>
+              <tbody id="leaderboardTableBody"></tbody>
+            </table>
+            <p id="leaderboardEmpty" class="analyzer-empty-state hidden">No production data available yet for this position.</p>
+          </div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(window.location.search);
+      const usernameParam = params.get('username');
+      const leagueParam = params.get('leagueId');
+
+      const usernameInput = document.getElementById('usernameInput');
+      const leagueSelect = document.getElementById('leagueSelect');
+      const loadingIndicator = document.getElementById('loading');
+      const infographicContent = document.getElementById('infographicContent');
+      const summaryStats = document.getElementById('summaryStats');
+      const startersToggleButtons = document.querySelectorAll('[data-starter-mode]');
+      const leaderboardButtons = document.querySelectorAll('[data-position-filter]');
+      const standingsTableBody = document.getElementById('standingsTableBody');
+      const leaderboardTableBody = document.getElementById('leaderboardTableBody');
+      const leaderboardEmpty = document.getElementById('leaderboardEmpty');
+      const starterChartSubtitle = document.getElementById('starterChartSubtitle');
+      const leagueMeta = document.getElementById('leagueMeta');
+      const leagueContext = document.getElementById('leagueContext');
+
+      let overallChart = null;
+      let startersChart = null;
+      let radarChart = null;
+
+      const POS_COLORS = {
+        QB: ['rgba(255, 58, 117, 0.9)', 'rgba(255, 58, 117, 0.45)'],
+        RB: ['rgba(0, 235, 199, 0.9)', 'rgba(0, 235, 199, 0.45)'],
+        WR: ['rgba(88, 167, 255, 0.9)', 'rgba(88, 167, 255, 0.45)'],
+        TE: ['rgba(180, 105, 255, 0.9)', 'rgba(180, 105, 255, 0.45)'],
+        FLEX: ['rgba(186, 101, 151, 0.9)', 'rgba(186, 101, 151, 0.45)'],
+        SUPER_FLEX: ['rgba(255, 58, 117, 0.8)', 'rgba(255, 58, 117, 0.4)'],
+        Picks: ['rgba(255, 199, 0, 0.85)', 'rgba(255, 199, 0, 0.4)']
+      };
+
+      const STARTER_SLOTS = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
+      const LEADERBOARD_POSITIONS = ['QB', 'RB', 'WR', 'TE'];
+
+      const POINTS_FORMATTER = new Intl.NumberFormat('en-US', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+      const INTEGER_FORMATTER = new Intl.NumberFormat('en-US');
+
+      let state = {
+        userId: null,
+        leagues: [],
+        players: {},
+        ktcOneQb: {},
+        ktcSflx: {},
+        currentLeagueId: null,
+        isSuperflex: false,
+        cache: {},
+        starterChartMode: 'ktc',
+        teams: [],
+        production: null,
+        activeLeaderboard: 'QB'
+      };
+
+      usernameInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          handleFetchData();
+        }
+      });
+
+      leagueSelect.addEventListener('change', () => {
+        if (leagueSelect.value) {
+          analyzeLeague(leagueSelect.value);
+        }
+      });
+
+      startersToggleButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const mode = button.dataset.starterMode;
+          if (!mode || mode === state.starterChartMode) return;
+          if (mode === 'ppg' && !(state.production?.weeksConsidered > 0)) return;
+          state.starterChartMode = mode;
+          updateStarterToggle();
+          renderStarterChart(state.teams);
         });
-    </script>
-    <script defer src="../scripts/app.js?v=20250826235225"></script>
+      });
+
+      leaderboardButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const position = button.dataset.positionFilter;
+          if (!position || position === state.activeLeaderboard) return;
+          state.activeLeaderboard = position;
+          updateLeaderboardTabs();
+          renderLeaderboard(position);
+        });
+      });
+
+      if (usernameParam) {
+        usernameInput.value = usernameParam;
+        handleFetchData();
+      }
+
+      async function handleFetchData() {
+        const username = usernameInput.value.trim();
+        if (!username) {
+          alert('Please enter a Sleeper username.');
+          return;
+        }
+
+        setLoading(true);
+        infographicContent.classList.add('hidden');
+        summaryStats.classList.add('hidden');
+        leagueContext.textContent = '';
+
+        try {
+          await Promise.all([fetchSleeperPlayers(), fetchKTCData()]);
+          await fetchUserAndLeagues(username);
+
+          if (state.leagues.length > 0) {
+            if (leagueParam) {
+              const exists = state.leagues.some((league) => league.league_id === leagueParam);
+              if (exists) {
+                leagueSelect.value = leagueParam;
+                await analyzeLeague(leagueParam);
+                return;
+              }
+            }
+            leagueSelect.selectedIndex = 1;
+            await analyzeLeague(state.leagues[0].league_id);
+          }
+        } catch (error) {
+          console.error('Error fetching data:', error);
+          alert(`An error occurred: ${error.message}`);
+        } finally {
+          setLoading(false);
+        }
+      }
+
+      async function fetchWithCache(url) {
+        if (state.cache[url]) {
+          return state.cache[url];
+        }
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`API request failed: ${response.statusText}`);
+        }
+        const data = await response.json();
+        state.cache[url] = data;
+        return data;
+      }
+
+      async function fetchSleeperPlayers() {
+        if (Object.keys(state.players).length > 0) return;
+        state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
+      }
+
+      async function fetchKTCData() {
+        if (Object.keys(state.ktcOneQb).length > 0) return;
+        const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
+        try {
+          const [oneQbCsv, sflxCsv] = await Promise.all([
+            fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then((res) => {
+              if (!res.ok) throw new Error('Failed to fetch 1QB KTC data: ' + res.statusText);
+              return res.text();
+            }),
+            fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then((res) => {
+              if (!res.ok) throw new Error('Failed to fetch SFLX KTC data: ' + res.statusText);
+              return res.text();
+            })
+          ]);
+          state.ktcOneQb = parseSheetData(oneQbCsv);
+          state.ktcSflx = parseSheetData(sflxCsv);
+        } catch (error) {
+          console.error('KTC Fetch Error:', error);
+          throw new Error('Could not retrieve KTC valuation data. Please try again later.');
+        }
+      }
+
+      function parseSheetData(csvText) {
+        const dataMap = {};
+        const lines = csvText.split(/?
+/).filter((line) => line.trim().length > 0);
+        if (lines.length === 0) return dataMap;
+
+        const parseLine = (line) => {
+          const result = [];
+          let current = '';
+          let inQuotes = false;
+          const sanitized = line.replace(/$/, '');
+
+          for (let i = 0; i < sanitized.length; i++) {
+            const char = sanitized[i];
+            if (inQuotes) {
+              if (char === '"') {
+                if (sanitized[i + 1] === '"') {
+                  current += '"';
+                  i++;
+                } else {
+                  inQuotes = false;
+                }
+              } else {
+                current += char;
+              }
+            } else if (char === '"') {
+              inQuotes = true;
+            } else if (char === ',') {
+              result.push(current.trim());
+              current = '';
+            } else {
+              current += char;
+            }
+          }
+          result.push(current.trim());
+          return result;
+        };
+
+        const normalize = (header) => header.replace(/[  ]/g, ' ').trim().toUpperCase();
+        const headers = parseLine(lines[0]).map((cell) => cell.trim());
+        const headerIndex = new Map();
+        headers.forEach((header, idx) => headerIndex.set(normalize(header), idx));
+
+        const getValue = (columns, names) => {
+          const keys = Array.isArray(names) ? names : [names];
+          for (const name of keys) {
+            const idx = headerIndex.get(normalize(name));
+            if (idx !== undefined && columns[idx] !== undefined) {
+              return columns[idx].trim();
+            }
+          }
+          return '';
+        };
+
+        const toInt = (value) => {
+          const num = parseInt(value, 10);
+          return Number.isNaN(num) ? null : num;
+        };
+
+        lines.slice(1).forEach((line) => {
+          const columns = parseLine(line);
+          if (!columns.length) return;
+
+          const pos = getValue(columns, 'POS');
+          const sleeperId = getValue(columns, 'SLPR_ID');
+          const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
+
+          if (pos === 'RDP') {
+            const pickName = getValue(columns, 'PLAYER NAME');
+            if (pickName) {
+              dataMap[pickName] = { ktc: ktcValue ?? 0 };
+            }
+            return;
+          }
+
+          if (!sleeperId || sleeperId === 'NA') return;
+
+          dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
+        });
+
+        return dataMap;
+      }
+
+      async function fetchUserAndLeagues(username) {
+        const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
+        if (!user || !user.user_id) throw new Error('Sleeper user not found.');
+        state.userId = user.user_id;
+
+        const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${new Date().getFullYear()}`);
+        if (!leagues || leagues.length === 0) throw new Error('No active leagues found for this user in the current season.');
+        state.leagues = leagues.sort((a, b) => a.name.localeCompare(b.name));
+
+        populateLeagueSelect(state.leagues);
+      }
+
+      async function analyzeLeague(leagueId) {
+        setLoading(true);
+        infographicContent.classList.add('hidden');
+        summaryStats.classList.add('hidden');
+        state.currentLeagueId = leagueId;
+
+        try {
+          const leagueInfo = state.leagues.find((league) => league.league_id === leagueId);
+          if (!leagueInfo) throw new Error('Unable to locate selected league details.');
+
+          const qbSlots = leagueInfo.roster_positions.filter((pos) => pos === 'QB').length;
+          const superflexSlots = leagueInfo.roster_positions.filter((pos) => pos === 'SUPER_FLEX').length;
+          state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
+
+          leagueMeta.textContent = `${leagueInfo.name} • ${leagueInfo.settings.num_teams}-team • ${state.isSuperflex ? 'Superflex' : '1QB'}`;
+          leagueContext.textContent = `Commissioner: ${leagueInfo.metadata?.owner || 'N/A'} · Season: ${leagueInfo.season}`;
+
+          const [rosters, users, tradedPicks] = await Promise.all([
+            fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
+            fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
+            fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`)
+          ]);
+
+          const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
+          const production = await computeProductionMetrics(leagueInfo, rosters, teams);
+
+          state.teams = teams;
+          state.production = production;
+          state.starterChartMode = production.weeksConsidered > 0 ? state.starterChartMode : 'ktc';
+
+          applyProductionToTeams(teams, production);
+          updateStarterToggle();
+          updateLeaderboardTabs();
+
+          renderSummaryStats(teams);
+          renderOverallChart(teams);
+          renderStarterChart(teams);
+          renderRadarChart(teams);
+          renderStandingsTable(teams);
+          renderLeaderboard(state.activeLeaderboard);
+
+          infographicContent.classList.remove('hidden');
+          summaryStats.classList.remove('hidden');
+        } catch (error) {
+          console.error('Analyze League Error:', error);
+          alert(`Failed to analyze league: ${error.message}`);
+        } finally {
+          setLoading(false);
+        }
+      }
+
+      function processLeagueData(rosters, users, tradedPicks, leagueInfo) {
+        const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
+        const teams = rosters.map((roster) => {
+          const owner = userMap[roster.owner_id];
+          const teamName = owner?.display_name || roster.metadata?.team_name || `Team ${roster.roster_id}`;
+          const record = roster.settings || {};
+          const totalPointsFor = parseSleeperPoints(record.fpts, record.fpts_decimal);
+          const totalPointsAgainst = parseSleeperPoints(record.fpts_against, record.fpts_against_decimal);
+
+          let topPlayer = { name: 'N/A', ktc: 0 };
+          const allPlayers = (roster.players || [])
+            .map((playerId) => {
+              const playerInfo = state.players[playerId];
+              const ktc = getKtcValue(playerId);
+              if (ktc > topPlayer.ktc) {
+                const first = playerInfo?.first_name || playerInfo?.first || '';
+                const last = playerInfo?.last_name || playerInfo?.last || 'Unknown';
+                const firstInitial = first ? `${first[0]}. ` : '';
+                topPlayer = { name: `${firstInitial}${last}`, ktc };
+              }
+              return { id: playerId, pos: playerInfo?.position, ktc };
+            })
+            .sort((a, b) => b.ktc - a.ktc);
+
+          const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
+          allPlayers.forEach((player) => {
+            if (overallPositional[player.pos] !== undefined) {
+              overallPositional[player.pos] += player.ktc;
+            }
+          });
+
+          getOwnedPicks(roster.roster_id, rosters, tradedPicks, leagueInfo).forEach((pick) => {
+            overallPositional.Picks += getKtcValue(pick.label);
+          });
+
+          const startersPositional = { QB: 0, RB: 0, WR: 0, TE: 0, FLEX: 0, SUPER_FLEX: 0 };
+          const startersPlayerDetails = { QB: [], RB: [], WR: [], TE: [], FLEX: [], SUPER_FLEX: [] };
+          const startersValueByPosition = { QB: 0, RB: 0, WR: 0, TE: 0 };
+          const starterIds = roster.starters || [];
+          const rosterPositions = leagueInfo.roster_positions;
+
+          starterIds.forEach((playerId, index) => {
+            const slot = rosterPositions[index];
+            const playerInfo = state.players[playerId];
+            const ktc = getKtcValue(playerId);
+
+            if (startersPositional[slot] !== undefined) {
+              startersPositional[slot] += ktc;
+              const first = playerInfo?.first_name || playerInfo?.first || '';
+              const last = playerInfo?.last_name || playerInfo?.last || 'Unknown';
+              startersPlayerDetails[slot].push({
+                name: `${first ? first[0] + '. ' : ''}${last}`,
+                ktc
+              });
+            }
+
+            if (playerInfo && startersValueByPosition[playerInfo.position] !== undefined) {
+              startersValueByPosition[playerInfo.position] += ktc;
+            }
+          });
+
+          const totalValue = Object.values(overallPositional).reduce((sum, value) => sum + value, 0);
+
+          return {
+            rosterId: roster.roster_id,
+            ownerId: roster.owner_id,
+            teamName,
+            ownerDisplay: owner?.display_name || teamName,
+            totalValue,
+            startersValue: Object.values(startersPositional).reduce((sum, value) => sum + value, 0),
+            overallPositional,
+            startersPositional,
+            startersPlayerDetails,
+            startersValueByPosition,
+            record: {
+              wins: record.wins || 0,
+              losses: record.losses || 0,
+              ties: record.ties || 0,
+              totalPointsFor,
+              totalPointsAgainst
+            },
+            roster,
+            topPlayer,
+            allPlayers,
+            isUserTeam: roster.owner_id === state.userId
+          };
+        });
+
+        teams.sort((a, b) => b.totalValue - a.totalValue);
+        return teams;
+      }
+
+      function getOwnedPicks(rosterId, allRosters, tradedPicks, leagueInfo) {
+        const currentYear = new Date().getFullYear();
+        const allPicks = [];
+
+        for (const roster of allRosters) {
+          for (let yearOffset = 1; yearOffset <= 4; yearOffset++) {
+            const season = currentYear + yearOffset;
+            for (let round = 1; round <= leagueInfo.settings.draft_rounds; round++) {
+              allPicks.push({
+                season: season.toString(),
+                round,
+                roster_id: roster.roster_id,
+                owner_id: roster.roster_id
+              });
+            }
+          }
+        }
+
+        tradedPicks.forEach((trade) => {
+          const pickIndex = allPicks.findIndex(
+            (pick) => pick.season === trade.season && pick.round === trade.round && pick.roster_id === trade.roster_id
+          );
+          if (pickIndex !== -1) {
+            allPicks[pickIndex].owner_id = trade.owner_id;
+          }
+        });
+
+        return allPicks
+          .filter((pick) => pick.owner_id === rosterId)
+          .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
+          .map((pick) => ({ ...pick, label: `${pick.season} Mid ${ordinal(pick.round)}` }));
+      }
+
+      async function computeProductionMetrics(leagueInfo, rosters, teams) {
+        const startWeek = Number(leagueInfo.settings?.start_week || 1);
+        const currentLeg = Number(leagueInfo.settings?.leg || leagueInfo.settings?.week || startWeek);
+        const playoffStart = Number(leagueInfo.settings?.playoff_start_week || currentLeg);
+        let completedWeeks = Math.max(currentLeg - 1, 0);
+        if (completedWeeks <= 0) {
+          completedWeeks = currentLeg > 0 ? currentLeg - 1 : 0;
+        }
+        const regularSeasonEnd = playoffStart > 0 ? playoffStart - 1 : completedWeeks;
+        const lastWeek = Math.max(Math.min(completedWeeks, regularSeasonEnd), 0);
+
+        if (lastWeek <= 0) {
+          return {
+            weeksConsidered: 0,
+            teamStarterPpg: {},
+            leaderboards: LEADERBOARD_POSITIONS.reduce((acc, pos) => ({ ...acc, [pos]: [] }), {})
+          };
+        }
+
+        const weeks = [];
+        for (let week = startWeek; week <= lastWeek; week++) {
+          weeks.push(week);
+        }
+
+        const matchupPromises = weeks.map((week) => fetchWithCache(`https://api.sleeper.app/v1/league/${leagueInfo.league_id}/matchups/${week}`));
+        const matchupsByWeek = await Promise.all(matchupPromises);
+
+        const teamProduction = {};
+        const contributors = {};
+        teams.forEach((team) => {
+          teamProduction[team.rosterId] = {
+            weeklyTotals: STARTER_SLOTS.reduce((acc, slot) => ({ ...acc, [slot]: [] }), {}),
+            weeks: 0
+          };
+          contributors[team.rosterId] = STARTER_SLOTS.reduce((acc, slot) => ({ ...acc, [slot]: {} }), {});
+        });
+
+        const playerStats = {};
+
+        matchupsByWeek.forEach((weekMatchups) => {
+          const totalsForWeek = {};
+
+          weekMatchups.forEach((entry) => {
+            const rosterId = entry.roster_id;
+            if (!teamProduction[rosterId]) return;
+
+            if (!totalsForWeek[rosterId]) {
+              totalsForWeek[rosterId] = STARTER_SLOTS.reduce((acc, slot) => ({ ...acc, [slot]: 0 }), {});
+            }
+
+            const starters = entry.starters || [];
+            const startersPoints = entry.starters_points || [];
+
+            starters.forEach((playerId, index) => {
+              const slot = leagueInfo.roster_positions[index];
+              if (!STARTER_SLOTS.includes(slot)) return;
+              const points = Number(startersPoints[index] ?? 0);
+              totalsForWeek[rosterId][slot] += points;
+
+              if (playerId && playerId !== '0') {
+                const playerInfo = state.players[playerId];
+                const position = playerInfo?.position || slot;
+                if (LEADERBOARD_POSITIONS.includes(position)) {
+                  if (!playerStats[playerId]) {
+                    playerStats[playerId] = { playerId, position, totalPoints: 0, games: 0, rosterId };
+                  }
+                  playerStats[playerId].totalPoints += points;
+                  playerStats[playerId].games += 1;
+                  playerStats[playerId].rosterId = rosterId;
+                }
+
+                const slotContributors = contributors[rosterId][slot];
+                if (!slotContributors[playerId]) {
+                  slotContributors[playerId] = { points: 0, games: 0 };
+                }
+                slotContributors[playerId].points += points;
+                slotContributors[playerId].games += 1;
+              }
+            });
+          });
+
+          Object.entries(totalsForWeek).forEach(([rosterId, totals]) => {
+            const record = teamProduction[rosterId];
+            if (!record) return;
+            record.weeks += 1;
+            STARTER_SLOTS.forEach((slot) => {
+              record.weeklyTotals[slot].push(totals[slot] || 0);
+            });
+          });
+        });
+
+        const teamStarterPpg = {};
+        Object.entries(teamProduction).forEach(([rosterId, record]) => {
+          const averages = {};
+          STARTER_SLOTS.forEach((slot) => {
+            const values = record.weeklyTotals[slot];
+            const total = values.reduce((sum, value) => sum + value, 0);
+            averages[slot] = record.weeks > 0 ? total / record.weeks : 0;
+          });
+
+          const slotContributors = contributors[rosterId];
+          const contributorDetails = {};
+          STARTER_SLOTS.forEach((slot) => {
+            const players = slotContributors[slot];
+            const details = Object.entries(players).map(([playerId, stats]) => {
+              const playerInfo = state.players[playerId];
+              return {
+                playerId,
+                name: formatPlayerName(playerInfo),
+                avg: stats.games > 0 ? stats.points / stats.games : 0
+              };
+            });
+            contributorDetails[slot] = details.sort((a, b) => b.avg - a.avg).slice(0, 3);
+          });
+
+          teamStarterPpg[rosterId] = {
+            averages,
+            totalAverage: STARTER_SLOTS.reduce((sum, slot) => sum + (averages[slot] || 0), 0),
+            weeksPlayed: record.weeks,
+            contributors: contributorDetails
+          };
+        });
+
+        const teamsByRoster = teams.reduce((acc, team) => {
+          acc[team.rosterId] = team;
+          return acc;
+        }, {});
+
+        const leaderboards = LEADERBOARD_POSITIONS.reduce((acc, position) => {
+          const entries = Object.values(playerStats)
+            .filter((player) => player.position === position && player.games > 0)
+            .map((player) => {
+              const playerInfo = state.players[player.playerId];
+              const ownerTeam = teamsByRoster[player.rosterId];
+              return {
+                playerId: player.playerId,
+                name: formatPlayerName(playerInfo),
+                position,
+                totalPoints: player.totalPoints,
+                games: player.games,
+                ppg: player.totalPoints / player.games,
+                ownerName: ownerTeam ? ownerTeam.teamName : 'Free Agent'
+              };
+            })
+            .sort((a, b) => b.totalPoints - a.totalPoints)
+            .slice(0, 10);
+          acc[position] = entries;
+          return acc;
+        }, {});
+
+        return {
+          weeksConsidered: lastWeek,
+          teamStarterPpg,
+          leaderboards
+        };
+      }
+
+      function applyProductionToTeams(teams, production) {
+        teams.forEach((team) => {
+          const starterPpg = production.teamStarterPpg[team.rosterId];
+          team.startersPpgBySlot = starterPpg?.averages || STARTER_SLOTS.reduce((acc, slot) => ({ ...acc, [slot]: 0 }), {});
+          team.startersPpgTotal = starterPpg?.totalAverage || 0;
+          team.startersWeeksPlayed = starterPpg?.weeksPlayed || 0;
+          team.starterContributors = starterPpg?.contributors || {};
+        });
+      }
+
+      function renderSummaryStats(teams) {
+        const userTeam = teams.find((team) => team.isUserTeam);
+        if (!userTeam) {
+          summaryStats.classList.add('hidden');
+          return;
+        }
+
+        const sortedByValue = [...teams].sort((a, b) => b.totalValue - a.totalValue);
+        const sortedByStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
+        const totalRank = sortedByValue.findIndex((team) => team.isUserTeam) + 1;
+        const starterRank = sortedByStarters.findIndex((team) => team.isUserTeam) + 1;
+
+        const positions = ['QB', 'RB', 'WR', 'TE'];
+        const positionalRanks = {};
+        positions.forEach((pos) => {
+          const sorted = [...teams].sort((a, b) => b.startersValueByPosition[pos] - a.startersValueByPosition[pos]);
+          positionalRanks[pos] = sorted.findIndex((team) => team.isUserTeam) + 1;
+        });
+
+        summaryStats.innerHTML = [
+          summaryCard('Overall Rank', `${totalRank}/${teams.length}`, getRankColor(totalRank, teams.length)),
+          summaryCard('Starters KTC', formatNumber(userTeam.startersValue)),
+          summaryCard('Total FPTS', formatPoints(userTeam.record.totalPointsFor)),
+          summaryCard('Top Player', `${userTeam.topPlayer.name}`, '#EAEBF0', `${formatNumber(userTeam.topPlayer.ktc)} KTC`),
+          summaryCard('QB Rank', `${positionalRanks.QB}/${teams.length}`, getRankColor(positionalRanks.QB, teams.length)),
+          summaryCard('RB Rank', `${positionalRanks.RB}/${teams.length}`, getRankColor(positionalRanks.RB, teams.length)),
+          summaryCard('WR Rank', `${positionalRanks.WR}/${teams.length}`, getRankColor(positionalRanks.WR, teams.length)),
+          summaryCard('TE Rank', `${positionalRanks.TE}/${teams.length}`, getRankColor(positionalRanks.TE, teams.length))
+        ].join('');
+      }
+
+      function summaryCard(label, value, color = '#EAEBF0', sublabel = '') {
+        return `
+          <article class="analyzer-summary-card glass-panel">
+            <p class="analyzer-summary-label">${label}</p>
+            <p class="analyzer-summary-value" style="color:${color}">${value}</p>
+            ${sublabel ? `<p class="analyzer-summary-subvalue">${sublabel}</p>` : ''}
+          </article>
+        `;
+      }
+
+      function renderOverallChart(teams) {
+        const labels = teams.map((team) => truncateLabel(team.teamName));
+        const positions = Object.keys(teams[0].overallPositional);
+        const datasets = positions.map((position) => ({
+          label: position === 'Picks' ? 'Future Picks' : position,
+          data: teams.map((team) => team.overallPositional[position]),
+          ...barStyleForPosition(position)
+        }));
+        const maxValue = Math.max(...teams.map((team) => team.totalValue));
+
+        if (overallChart) overallChart.destroy();
+        overallChart = new Chart(document.getElementById('overallValueChart'), {
+          type: 'bar',
+          data: { labels, datasets },
+          options: createBarChartOptions({
+            mode: 'ktc',
+            maxValue,
+            stacked: true,
+            tooltipFormatter: (context) => `${context.dataset.label}: ${formatNumber(context.raw)}`
+          })
+        });
+      }
+
+      function renderStarterChart(teams) {
+        const mode = state.starterChartMode === 'ppg' && state.production?.weeksConsidered > 0 ? 'ppg' : 'ktc';
+        if (mode === 'ktc') {
+          starterChartSubtitle.textContent = 'KTC valuation across starter slots';
+        } else {
+          starterChartSubtitle.textContent = `Average fantasy points per game (through week ${state.production.weeksConsidered})`;
+        }
+
+        const sortedTeams = [...teams].sort((a, b) => {
+          const aValue = mode === 'ktc' ? a.startersValue : a.startersPpgTotal;
+          const bValue = mode === 'ktc' ? b.startersValue : b.startersPpgTotal;
+          return bValue - aValue;
+        });
+
+        const labels = sortedTeams.map((team) => truncateLabel(team.teamName));
+        const datasets = STARTER_SLOTS.filter((slot) => sortedTeams.some((team) => {
+          const value = mode === 'ktc' ? team.startersPositional[slot] : team.startersPpgBySlot[slot];
+          return value > 0;
+        })).map((slot) => ({
+          label: slot.replace('_', ' '),
+          data: sortedTeams.map((team) => mode === 'ktc' ? team.startersPositional[slot] : team.startersPpgBySlot[slot]),
+          ...barStyleForPosition(slot)
+        }));
+
+        const maxValue = Math.max(
+          ...sortedTeams.map((team) => mode === 'ktc' ? team.startersValue : team.startersPpgTotal)
+        );
+
+        if (startersChart) startersChart.destroy();
+        startersChart = new Chart(document.getElementById('startersValueChart'), {
+          type: 'bar',
+          data: { labels, datasets },
+          options: createBarChartOptions({
+            mode,
+            maxValue,
+            stacked: true,
+            teamsForTooltip: sortedTeams,
+            tooltipFormatter: (context) => {
+              if (mode === 'ktc') {
+                return `${context.dataset.label}: ${formatNumber(context.raw)}`;
+              }
+              return `${context.dataset.label}: ${formatPoints(context.raw)} PPG`;
+            }
+          })
+        });
+      }
+
+      function renderRadarChart(teams) {
+        const userTeam = teams.find((team) => team.isUserTeam);
+        if (!userTeam) return;
+
+        const leagueAverages = { QB: 0, RB: 0, WR: 0, TE: 0 };
+        const userValues = { QB: 0, RB: 0, WR: 0, TE: 0 };
+        const positions = ['QB', 'RB', 'WR', 'TE'];
+
+        positions.forEach((pos) => {
+          let totalLeagueKTC = 0;
+          teams.forEach((team) => {
+            const topTwoPlayers = team.allPlayers.filter((player) => player.pos === pos).slice(0, 2);
+            totalLeagueKTC += topTwoPlayers.reduce((sum, player) => sum + player.ktc, 0);
+          });
+          leagueAverages[pos] = totalLeagueKTC / teams.length;
+
+          const userTopTwo = userTeam.allPlayers.filter((player) => player.pos === pos).slice(0, 2);
+          userValues[pos] = userTopTwo.reduce((sum, player) => sum + player.ktc, 0);
+        });
+
+        if (radarChart) radarChart.destroy();
+        radarChart = new Chart(document.getElementById('radarChart'), {
+          type: 'radar',
+          data: {
+            labels: positions,
+            datasets: [
+              {
+                label: 'Your Team (Top 2)',
+                data: Object.values(userValues),
+                fill: true,
+                backgroundColor: 'rgba(118, 109, 255, 0.35)',
+                borderColor: 'rgba(118, 109, 255, 0.85)',
+                pointBackgroundColor: 'rgba(118, 109, 255, 1)',
+                pointBorderColor: '#fff'
+              },
+              {
+                label: 'League Average (Top 2)',
+                data: Object.values(leagueAverages),
+                fill: true,
+                backgroundColor: 'rgba(66, 194, 255, 0.3)',
+                borderColor: 'rgba(66, 194, 255, 0.9)',
+                pointBackgroundColor: 'rgba(66, 194, 255, 1)',
+                pointBorderColor: '#fff'
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            elements: {
+              line: { borderWidth: 2 }
+            },
+            scales: {
+              r: {
+                beginAtZero: true,
+                angleLines: { color: 'rgba(255, 255, 255, 0.15)' },
+                grid: { color: 'rgba(255, 255, 255, 0.12)' },
+                pointLabels: {
+                  color: '#EAEBF0',
+                  font: { family: 'Product Sans, sans-serif', size: 13 }
+                },
+                ticks: {
+                  color: '#9096C0',
+                  backdropColor: 'rgba(10, 12, 30, 0.6)',
+                  font: { family: 'Product Sans, sans-serif' }
+                }
+              }
+            },
+            plugins: {
+              legend: {
+                position: 'top',
+                labels: {
+                  color: '#EAEBF0',
+                  usePointStyle: true,
+                  font: { family: 'Product Sans, sans-serif' }
+                }
+              }
+            }
+          }
+        });
+      }
+
+      function renderStandingsTable(teams) {
+        const sorted = [...teams].sort((a, b) => {
+          if (b.record.wins !== a.record.wins) return b.record.wins - a.record.wins;
+          if (b.record.losses !== a.record.losses) return a.record.losses - b.record.losses;
+          return b.record.totalPointsFor - a.record.totalPointsFor;
+        });
+
+        standingsTableBody.innerHTML = sorted
+          .map((team, index) => {
+            const isUser = team.isUserTeam;
+            return `
+              <tr class="${isUser ? 'is-user-team' : ''}">
+                <td>${index + 1}</td>
+                <td>
+                  <div class="team-name-cell">
+                    <span class="team-name">${team.teamName}</span>
+                    ${isUser ? '<span class="team-pill">You</span>' : ''}
+                  </div>
+                </td>
+                <td>${formatRecord(team.record)}</td>
+                <td>${formatPoints(team.record.totalPointsFor)}</td>
+                <td>${formatPoints(team.record.totalPointsAgainst)}</td>
+              </tr>
+            `;
+          })
+          .join('');
+      }
+
+      function renderLeaderboard(position) {
+        const entries = state.production?.leaderboards?.[position] || [];
+        leaderboardTableBody.innerHTML = entries
+          .map((entry, index) => {
+            return `
+              <tr>
+                <td>${index + 1}</td>
+                <td>
+                  <div class="leader-player">
+                    <span class="leader-player-name">${entry.name}</span>
+                    <span class="leader-player-meta">${position}</span>
+                  </div>
+                </td>
+                <td>${entry.ownerName}</td>
+                <td>${formatPoints(entry.totalPoints)}</td>
+                <td>${formatPoints(entry.ppg)}</td>
+                <td>${entry.games}</td>
+              </tr>
+            `;
+          })
+          .join('');
+
+        if (entries.length === 0) {
+          leaderboardEmpty.classList.remove('hidden');
+        } else {
+          leaderboardEmpty.classList.add('hidden');
+        }
+      }
+
+      function createBarChartOptions({ mode, maxValue, stacked = false, teamsForTooltip = null, tooltipFormatter }) {
+        const tooltipCallbacks = {
+          label: (context) => tooltipFormatter(context)
+        };
+
+        if (teamsForTooltip) {
+          tooltipCallbacks.footer = (tooltipItems) => {
+            const teamIndex = tooltipItems[0].dataIndex;
+            const datasetLabel = tooltipItems[0].dataset.label;
+            const team = teamsForTooltip[teamIndex];
+
+            if (mode === 'ktc') {
+              const details = team.startersPlayerDetails?.[datasetLabel.replace(' ', '_')] || team.startersPlayerDetails?.[datasetLabel];
+              if (details && details.length) {
+                return details
+                  .sort((a, b) => b.ktc - a.ktc)
+                  .slice(0, 3)
+                  .map((player) => `${player.name}: ${formatNumber(player.ktc)} KTC`)
+                  .join('
+');
+              }
+            } else if (mode === 'ppg') {
+              const contributors = team.starterContributors?.[datasetLabel.replace(' ', '_')] || team.starterContributors?.[datasetLabel];
+              if (contributors && contributors.length) {
+                return contributors
+                  .map((player) => `${player.name}: ${formatPoints(player.avg)} PPG`)
+                  .join('
+');
+              }
+            }
+            return '';
+          };
+        }
+
+        return {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          layout: { padding: { left: 0, right: 12, top: 8, bottom: 8 } },
+          scales: {
+            x: {
+              stacked,
+              grid: { color: 'rgba(255, 255, 255, 0.08)' },
+              ticks: {
+                color: '#EAEBF0',
+                font: { family: 'Product Sans, sans-serif' },
+                callback: (value) => {
+                  if (mode === 'ktc') {
+                    return formatNumber(value);
+                  }
+                  return formatPoints(value);
+                }
+              },
+              max: mode === 'ktc' ? Math.ceil(maxValue / 5000) * 5000 : Math.ceil(maxValue / 5) * 5
+            },
+            y: {
+              stacked,
+              grid: { color: 'rgba(255, 255, 255, 0.02)' },
+              ticks: {
+                color: '#EAEBF0',
+                font: { family: 'Product Sans, sans-serif', size: 12 }
+              }
+            }
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                color: '#EAEBF0',
+                usePointStyle: true,
+                font: { family: 'Product Sans, sans-serif' }
+              }
+            },
+            tooltip: {
+              backgroundColor: 'rgba(10, 12, 30, 0.9)',
+              borderColor: 'rgba(118, 109, 255, 0.45)',
+              borderWidth: 1,
+              padding: 12,
+              displayColors: false,
+              callbacks: tooltipCallbacks
+            }
+          }
+        };
+      }
+
+      function barStyleForPosition(position) {
+        const colors = POS_COLORS[position] || POS_COLORS.QB;
+        return {
+          borderRadius: 12,
+          borderSkipped: false,
+          borderWidth: 1,
+          borderColor: colors[0],
+          backgroundColor: (context) => {
+            const { ctx, chartArea } = context.chart;
+            if (!chartArea) return colors[0];
+            const gradient = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0);
+            gradient.addColorStop(0, colors[0]);
+            gradient.addColorStop(1, colors[1] ?? colors[0]);
+            return gradient;
+          }
+        };
+      }
+
+      function updateStarterToggle() {
+        const hasPpg = state.production?.weeksConsidered > 0;
+        startersToggleButtons.forEach((button) => {
+          const mode = button.dataset.starterMode;
+          if (mode === state.starterChartMode) {
+            button.classList.add('active');
+          } else {
+            button.classList.remove('active');
+          }
+          if (mode === 'ppg') {
+            button.disabled = !hasPpg;
+            button.classList.toggle('disabled', !hasPpg);
+          }
+        });
+      }
+
+      function updateLeaderboardTabs() {
+        leaderboardButtons.forEach((button) => {
+          const position = button.dataset.positionFilter;
+          if (position === state.activeLeaderboard) {
+            button.classList.add('active');
+          } else {
+            button.classList.remove('active');
+          }
+        });
+      }
+
+      function truncateLabel(label) {
+        return label.length > 14 ? `${label.slice(0, 13)}…` : label;
+      }
+
+      function parseSleeperPoints(base, decimal) {
+        const whole = Number(base || 0);
+        const fractional = Number(decimal || 0) / 100;
+        return Number((whole + fractional).toFixed(2));
+      }
+
+      function formatNumber(value) {
+        return INTEGER_FORMATTER.format(Math.round(value));
+      }
+
+      function formatPoints(value) {
+        return POINTS_FORMATTER.format(value || 0);
+      }
+
+      function formatRecord(record) {
+        const parts = [record.wins, record.losses];
+        if (record.ties) {
+          parts.push(record.ties);
+        }
+        return parts.join('-');
+      }
+
+      function formatPlayerName(playerInfo) {
+        if (!playerInfo) return 'Unknown Player';
+        const first = playerInfo.first_name || playerInfo.first || '';
+        const last = playerInfo.last_name || playerInfo.last || '';
+        const team = playerInfo.team ? playerInfo.team.toUpperCase() : '';
+        return [first, last].filter(Boolean).join(' ') + (team ? ` · ${team}` : '');
+      }
+
+      function ordinal(i) {
+        const j = i % 10;
+        const k = i % 100;
+        if (j === 1 && k !== 11) return `${i}st`;
+        if (j === 2 && k !== 12) return `${i}nd`;
+        if (j === 3 && k !== 13) return `${i}rd`;
+        return `${i}th`;
+      }
+
+      function getKtcValue(id) {
+        const source = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
+        return source[id]?.ktc || 0;
+      }
+
+      function getRankColor(rank, total) {
+        const percentile = (total - rank + 1) / total;
+        if (percentile >= 0.8) return '#00EBC7';
+        if (percentile >= 0.6) return '#58A7FF';
+        if (percentile >= 0.4) return '#EAEBF0';
+        if (percentile >= 0.2) return '#FF7F50';
+        return '#FF3A75';
+      }
+
+      function populateLeagueSelect(leagues) {
+        leagueSelect.innerHTML = '<option value="">Select a league...</option>';
+        leagues.forEach((league) => {
+          const option = document.createElement('option');
+          option.value = league.league_id;
+          option.textContent = league.name;
+          leagueSelect.appendChild(option);
+        });
+        leagueSelect.disabled = false;
+      }
+
+      function setLoading(isLoading) {
+        if (isLoading) {
+          loadingIndicator.classList.remove('hidden');
+        } else {
+          loadingIndicator.classList.add('hidden');
+        }
+      }
+    });
+  </script>
+  <script defer src="../scripts/app.js?v=20250826235225"></script>
 </body>
 </html>
-
-
-

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -5865,3 +5865,281 @@ body[data-page="research"] .app-header {
   background: rgb(67 71 87 / 63%);
 }
 
+
+/* === League Analyzer === */
+.analyzer-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.analyzer-hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--panel-border-radius);
+}
+
+.analyzer-hero-intro h1 {
+  font-size: clamp(1.75rem, 2.8vw, 2.4rem);
+  margin-bottom: 0.35rem;
+}
+
+.analyzer-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(118, 109, 255, 0.18);
+  border: 1px solid rgba(118, 109, 255, 0.45);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent-secondary);
+}
+
+.analyzer-hero-meta {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.analyzer-hero-context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.analyzer-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.analyzer-summary-card {
+  padding: 0.85rem;
+  border-radius: var(--card-border-radius);
+  background: rgba(22, 24, 43, 0.35);
+  border: 1px solid rgba(118, 109, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.analyzer-summary-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.analyzer-summary-value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.analyzer-summary-subvalue {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+}
+
+.analyzer-loading {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  border-radius: var(--panel-border-radius);
+  color: var(--color-text-secondary);
+}
+
+.analyzer-panels-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 1024px) {
+  .analyzer-panels-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.analyzer-panel {
+  padding: 1.5rem;
+  border-radius: var(--panel-border-radius);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.analyzer-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.analyzer-panel-header h2 {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.analyzer-panel-subtitle {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.analyzer-toggle {
+  display: inline-flex;
+  background: rgba(13, 14, 35, 0.4);
+  border: 1px solid rgba(118, 109, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.15rem;
+}
+
+.analyzer-toggle-button {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  transition: all 0.2s ease;
+}
+
+.analyzer-toggle-button:hover:not(.disabled),
+.analyzer-toggle-button:focus-visible {
+  color: var(--color-text-primary);
+}
+
+.analyzer-toggle-button.active {
+  background: linear-gradient(135deg, rgba(118, 109, 255, 0.85), rgba(66, 194, 255, 0.75));
+  color: #0d0e1b;
+  box-shadow: 0 8px 16px rgba(118, 109, 255, 0.3);
+}
+
+.analyzer-toggle-button.disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.chart-container {
+  position: relative;
+  height: 360px;
+}
+
+.analyzer-table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--card-border-radius);
+}
+
+.analyzer-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 540px;
+}
+
+.analyzer-table thead th {
+  text-align: left;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.analyzer-table tbody td {
+  padding: 0.65rem 0.75rem;
+  font-size: 0.9rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.analyzer-table tbody tr:hover {
+  background: rgba(118, 109, 255, 0.08);
+}
+
+.analyzer-table tbody tr.is-user-team {
+  background: rgba(118, 109, 255, 0.12);
+}
+
+.team-name-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.team-pill {
+  font-size: 0.65rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(118, 109, 255, 0.25);
+  border: 1px solid rgba(118, 109, 255, 0.4);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.analyzer-leaderboard-tabs {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.leaderboard-tab {
+  border: 1px solid rgba(118, 109, 255, 0.25);
+  background: rgba(15, 16, 32, 0.6);
+  color: var(--color-text-secondary);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  transition: all 0.2s ease;
+}
+
+.leaderboard-tab:hover,
+.leaderboard-tab:focus-visible {
+  color: var(--color-text-primary);
+  border-color: rgba(118, 109, 255, 0.45);
+}
+
+.leaderboard-tab.active {
+  background: linear-gradient(135deg, rgba(118, 109, 255, 0.85), rgba(66, 194, 255, 0.75));
+  color: #0d0e1b;
+  border-color: transparent;
+  box-shadow: 0 10px 18px rgba(118, 109, 255, 0.25);
+}
+
+.leader-player {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.leader-player-name {
+  font-weight: 600;
+}
+
+.leader-player-meta {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+}
+
+.analyzer-empty-state {
+  margin-top: 0.75rem;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 768px) {
+  .analyzer-panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chart-container {
+    height: 300px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- restyle the League Analyzer shell with the shared glassmorphism theme, refreshed hero, summary chips, charts, standings, and leaderboards
- compute Sleeper production metrics to power starter PPG toggles, league standings, and position leaderboards while replacing the starters rank chip with total FPTS
- enhance chart rendering with new gradients, tooltips, and toggle controls for value vs. production views

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4254a6d10832e88eb7a7115e87c37