### PR TITLE
Revamp league analyzer experience

### DIFF
--- a/DHP2_DeployDraft1.2/analyzer/analyzer.html
+++ b/DHP2_DeployDraft1.2/analyzer/analyzer.html
@@ -1,998 +1,210 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sleeper League KTC Infographic</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&family=Product+Sans:wght@400;700&display=swap" rel="stylesheet">
-    <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet"/>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
-    <style>
-        :root {
-            --font-sans: 'Product Sans', 'Google Sans', 'Quicksand', sans-serif;
-            --color-bg: #0D0E1B;
-            --color-panel-border: rgba(128, 138, 189, 0.2);
-            --color-text-primary: #EAEBF0;
-            --color-text-secondary: #9096C0;
-            --color-accent-primary: #766DFF;
-            --color-accent-primary-glow: rgba(118, 109, 255, 0.5);
-        }
-
-        body {
-            font-family: var(--font-sans);
-            background-color: var(--color-bg);
-            color: var(--color-text-primary);
-            overflow-x: hidden;
-        }
-
-        #starfield {
-            position: fixed; inset: 0; z-index: -10; pointer-events: none;
-            background: radial-gradient(ellipse at 50% 100%, #1B2735 0%, #090A0F 100%);
-        }
-
-        #stars1, #stars2, #stars3 {
-            position: absolute; left: 0; top: 0;
-            background: transparent;
-            animation: animStar linear infinite;
-        }
-
-        #stars1 { width: 1px; height: 1px; box-shadow: 1528px 425px #FFF, 1965px 1848px #FFF, 466px 588px #FFF, 1441px 1361px #FFF, 395px 1296px #FFF, 1603px 1631px #FFF, 1403px 1363px #FFF, 1010px 54px #FFF, 904px 1539px #FFF, 929px 1400px #FFF, 1370px 1286px #FFF, 612px 1109px #FFF, 1899px 1371px #FFF, 215px 873px #FFF, 1997px 882px #FFF, 283px 759px #FFF, 1675px 1005px #FFF, 145px 1973px #FFF, 1974px 1948px #FFF, 128px 1115px #FFF, 1863px 1335px #FFF, 1540px 938px #FFF, 1739px 491px #FFF, 1898px 1397px #FFF, 706px 1264px #FFF, 1505px 1162px #FFF, 200px 1889px #FFF, 1044px 1230px #FFF, 315px 1227px #FFF, 625px 217px #FFF, 1813px 1135px #FFF, 287px 791px #FFF, 1131px 816px #FFF, 845px 87px #FFF, 272px 94px #FFF, 1341px 1194px #FFF, 1547px 893px #FFF, 1460px 1971px #FFF, 655px 1052px #FFF, 1178px 815px #FFF, 1643px 1785px #FFF, 1172px 277px #FFF, 1486px 280px #FFF, 134px 1224px #FFF, 338px 213px #FFF, 814px 1844px #FFF, 1207px 806px #FFF, 14px 526px #FFF, 957px 455px #7300ff, 518px 864px #7300ff, 321px 438px #7300ff, 1226px 1328px #FFF, 784px 1010px #FF0266, 1052px 1568px #FF0266, 350px 478px #FF0266; animation-duration: 450s; }
-        #stars2 { width: 2px; height: 2px; box-shadow: 444px 26px #FFF, 644px 550px #FFF, 428px 426px #FFF, 12px 1913px #FFF, 680px 225px #FFF, 1346px 474px #FFF, 6px 1693px #FFF, 1555px 996px #FFF, 579px 1620px #FFF, 364px 1911px #FFF, 282px 1788px #FFF, 280px 337px #FFF, 1880px 1547px #FF0266, 1531px 1567px #FF0266, 193px 1099px #FF0266, 1540px 17px #FF0266, 1774px 292px #FF0266, 183px 775px #FF0266, 214px 107px #FFF, 695px 88px #FFF, 490px 1209px #FFF, 1374px 560px #FFF, 752px 1759px #FFF, 1985px 866px #FFF, 609px 310px #FFF, 86px 1036px #FFF, 638px 191px #FFF, 1635px 626px #FFF, 78px 998px #FFF, 1189px 1345px #FFF, 48px 1383px #FFF, 1981px 345px #FFF, 1993px 1838px #FFF, 717px 1540px #FFF, 287px 673px #FFF, 1821px 1665px #FFF, 686px 600px #FFF, 572px 777px #FFF, 932px 537px #FFF, 1808px 1538px #FFF, 1563px 305px #FFF, 1771px 1974px #FFF, 393px 1768px #FFF, 368px 1426px #FFF, 434px 779px #FFF, 566px 1370px #FFF, 261px 791px #FFF, 141px 434px #1ACDD1; animation-duration: 400s; }
-        #stars3 { width: 3px; height: 3px; box-shadow: 1208px 1620px #FF0070, 576px 1883px #FFF, 1810px 913px #FFF, 87px 1117px #FFF, 1076px 1851px #FFF, 859px 264px #FFF, 1469px 1346px #FFF, 1651px 1493px #FFF, 767px 822px #FFF, 359px 967px #FFF, 1009px 808px #FF0070, 100px 1656px #7300ff, 1365px 1511px #7300ff, 429px 1279px #7300ff, 1381px 1850px #E86439, 1896px 1999px #E86439, 236px 718px #7300ff, 39px 1731px #7300ff, 562px 1084px #7300ff, 1067px 1431px #FF0266, 1362px 1575px #FF0266, 953px 1860px #FF0266, 1498px 499px #FF0266, 1055px 885px #FFF, 1824px 1334px #FFF, 519px 1319px #FFF, 1716px 1538px #FFF, 1305px 524px #FFF, 808px 1972px #FFF, 426px 649px #FFF, 882px 1530px #FFF, 623px 557px #FFF, 129px 1750px #FF0070; animation-duration: 350s; }
-        
-        @keyframes animStar { from { transform: translateY(0px); } to { transform: translateY(-2000px); } }
-
-        .glass-panel {
-            background-color: rgba(13, 14, 35, 0.21);
-            background-image: linear-gradient(rgba(255,255,255, 0.03), rgba(255,255,255, 0.03));
-            backdrop-filter: blur(6px) saturate(120%) brightness(120%);
-            border: 1px solid rgba(128, 138, 189, 0.2);
-            border-radius: 10px;
-            box-shadow: inset 0 0 0 1px rgba(255,255,255, 0.05), 
-                        inset 0 0 0 2px rgba(200,200,200, 0.025), 
-                        0 10px 26px rgba(0,0,0, .22);
-        }
-        
-        h1, h2, h3 {
-            font-family: var(--font-sans);
-            color: var(--color-text-primary);
-            text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
-        }
-        h1 { font-weight: 700; }
-        h2 { font-weight: 500; }
-        h3 { font-weight: 500; }
-        
-        .chart-container {
-            position: relative;
-            height: 450px;
-            width: 100%;
-        }
-
-        .power-grid-item h3 {
-            font-size: 1rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: .8px;
-            color: var(--color-text-primary);
-            text-align: center;
-            padding: 0.2rem 0;
-            margin-bottom: 0.5rem;
-            position: relative;
-            border: 1px solid var(--color-panel-border);
-            border-radius: 5px;
-            backdrop-filter: saturate(114%) blur(1px);
-            overflow: hidden;
-        }
-
-        .power-grid-item h3::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            border-radius: inherit;
-            pointer-events: none;
-            background-color: rgba(20, 28, 58, 0.15);
-            background-image: linear-gradient(rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 35%);
-        }
-
-
-        /* Fix for browser autofill styles */
-        input:-webkit-autofill,
-        input:-webkit-autofill:hover,
-        input:-webkit-autofill:focus,
-        input:-webkit-autofill:active {
-            -webkit-box-shadow: 0 0 0 30px #0D0E1B inset !important; /* Match body bg */
-            -webkit-text-fill-color: #c4c8ea !important;
-            transition: background-color 5000s ease-in-out 0s;
-            caret-color: #c4c8ea;
-        }
-
-        #usernameInput, #leagueSelect {
-            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
-            border: 1px solid var(--color-panel-border);
-            border-radius: 8px;
-            backdrop-filter: blur(4px) saturate(110%);
-            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-            color: #c4c8ea;
-            transition: all 0.2s ease;
-        }
-
-        #usernameInput:focus, #leagueSelect:focus {
-            outline: none;
-            border-color: var(--color-accent-primary);
-            box-shadow: 0 0 8px var(--color-accent-primary-glow);
-        }
-
-    </style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>League Analyzer • Dynasty Hub</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@200;300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Product+Sans:wght@100;200;300;400;500;700;900&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css?family=Google+Sans:100,200,300,400,500,600,700" rel="stylesheet" />
+  <link href="../manifest.webmanifest?v=20250827002411?v=20250826235225" rel="manifest" />
+  <link rel="apple-touch-icon" sizes="180x180" href="../assets/icons/apple-touch-icon-180.png?v=20250827002411?v=20250826235225" />
+  <meta name="theme-color" content="#0D0E1B" />
+  <link href="../styles/styles.css?v=20250827002411?v=20250826235225" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/icons/favicon-32.png?v=20250827002411?v=20250826235225" />
+  <link rel="icon" type="image/png" sizes="16x16" href="../assets/icons/favicon-16.png?v=20250827002411?v=20250826235225" />
+  <link rel="shortcut icon" href="../assets/icons/favicon.ico?v=20250827002411?v=20250826235225" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body data-page="analyzer" class="p-2 sm:p-4">
-    <!-- Replaced Background: Starfield -->
-    <div aria-hidden="true" id="starfield">
-        <div id="stars1"></div>
-        <div id="stars2"></div>
-        <div id="stars3"></div>
+  <div aria-hidden="true" id="starfield">
+    <div id="stars"></div>
+    <div id="stars1"></div>
+    <div id="stars2"></div>
+    <div id="stars3"></div>
+  </div>
+  <div id="noise-overlay"></div>
+  <div class="relative z-10 content-wrapper">
+    <div id="header-container">
+      <header class="app-header glass-panel">
+        <div class="header-row">
+          <div class="menu-container">
+            <button id="menu-button" class="menu-button" aria-label="Toggle navigation">
+              <svg viewBox="0 0 100 80" width="20" height="20" aria-hidden="true">
+                <rect width="100" height="15"></rect>
+                <rect y="30" width="100" height="15"></rect>
+                <rect y="60" width="100" height="15"></rect>
+              </svg>
+            </button>
+            <div id="dropdown-menu" class="dropdown-menu hidden">
+              <a href="../index.html">
+                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
+                <span>Home</span>
+              </a>
+              <a href="#" id="menu-rosters">
+                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
+                <span>Rosters</span>
+              </a>
+              <a href="#" id="menu-ownership">
+                <i class="fa-solid fa-percent" aria-hidden="true"></i>
+                <span>Ownership</span>
+              </a>
+              <a href="#" id="menu-research">
+                <i class="fa-solid fa-flask" aria-hidden="true"></i>
+                <span>Research</span>
+              </a>
+              <a href="#" id="menu-analyzer" class="active">
+                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
+                <span>League Analyzer</span>
+              </a>
+            </div>
+          </div>
+          <div class="username-area">
+            <label class="sr-only" for="usernameInput">Sleeper username</label>
+            <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle" />
+          </div>
+          <div class="custom-select-wrapper">
+            <label class="sr-only" for="leagueSelect">Active league</label>
+            <select id="leagueSelect" disabled>
+              <option>Select a league...</option>
+            </select>
+          </div>
+        </div>
+      </header>
     </div>
-    <div id="noise-overlay"></div>
-    <div class="relative z-10 content-wrapper">
-        <div id="header-container">
-            <header class="app-header glass-panel">
-                <div class="header-row">
-                    <div class="menu-container">
-                        <button id="menu-button" class="menu-button">
-                            <svg viewBox="0 0 100 80" width="20" height="20">
-                                <rect width="100" height="15"></rect>
-                                <rect y="30" width="100" height="15"></rect>
-                                <rect y="60" width="100" height="15"></rect>
-                            </svg>
-                        </button>
-                        <div id="dropdown-menu" class="dropdown-menu hidden">
-                            <a href="../">
-                                <i class="fa-solid fa-house-user" aria-hidden="true"></i>
-                                <span>Home</span>
-                            </a>
-                            <a href="#" id="menu-rosters">
-                                <i class="fa-solid fa-clipboard-list" aria-hidden="true"></i>
-                                <span>Rosters</span>
-                            </a>
-                            <a href="#" id="menu-ownership">
-                                <i class="fa-solid fa-percent" aria-hidden="true"></i>
-                                <span>Ownership</span>
-                            </a>
-                            <a href="#" id="menu-research">
-                                <i class="fa-solid fa-flask" aria-hidden="true"></i>
-                                <span>Research</span>
-                            </a>
-                            <a href="#" id="menu-analyzer">
-                                <i class="fa-solid fa-square-poll-vertical" aria-hidden="true"></i>
-                                <span>League Analyzer</span>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="username-area">
-                        <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
-                    </div>
-                    <div class="custom-select-wrapper">
-                        <select id="leagueSelect" disabled>
-                            <option>Select a league...</option>
-                        </select>
-                    </div>
-                </div>
+    <main class="container mx-auto analyzer-main" id="content">
+      <section class="analyzer-hero glass-panel" aria-labelledby="analyzer-hero-heading">
+        <div class="analyzer-hero-intro">
+          <div class="analyzer-pill">Dynasty Hub Analyzer</div>
+          <h1 id="analyzer-hero-heading">League Value &amp; Production Overview</h1>
+          <p>Track KTC valuations alongside real Sleeper scoring to uncover strengths across every roster.</p>
+        </div>
+        <div class="analyzer-hero-controls">
+          <div class="analyzer-control-group">
+            <span class="control-label">Username</span>
+            <p class="control-value" id="activeUsername">&mdash;</p>
+          </div>
+          <div class="analyzer-control-group">
+            <span class="control-label">League</span>
+            <p class="control-value" id="activeLeague">Select a league...</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="loading" class="analyzer-loading glass-panel hidden" role="status" aria-live="polite">
+        <div class="loading-indicator">Analyzing league data&hellip;</div>
+      </section>
+
+      <section id="summaryStats" class="analyzer-summary-grid hidden" aria-live="polite" aria-label="Team summary"></section>
+
+      <section id="infographicContent" class="analyzer-content hidden">
+        <div class="analyzer-panels-grid">
+          <article class="analyzer-panel glass-panel" id="lineup-panel">
+            <header class="analyzer-panel-header">
+              <div>
+                <h2>Starting Lineup Overview</h2>
+                <p>Toggle between market value and combined starter production.</p>
+              </div>
+              <div class="analyzer-toggle" role="group" aria-label="Lineup metric">
+                <button type="button" class="toggle-option active" data-metric="value" aria-pressed="true">Value</button>
+                <button type="button" class="toggle-option" data-metric="ppg" aria-pressed="false">PPG</button>
+              </div>
             </header>
-        </div>
-        <main class="container mx-auto" id="content">
-            <div class="max-w-7xl mx-auto space-y-2 md:space-y-4">
-                <!-- Page Header -->
-                <header class="text-center space-y-2">
-                    <h1 class="text-2xl md:text-3xl font-bold tracking-wider">Dynasty League Power Rankings</h1>
-                    <p class="text-md text-gray-400">KTC Team Value Analysis</p>
-                </header>
+            <div class="analyzer-panel-body">
+              <div class="chart-container analyzer-chart">
+                <canvas id="startersValueChart" aria-label="Starting lineup comparison" role="img"></canvas>
+              </div>
+            </div>
+          </article>
 
-                <!-- Summary Stats -->
-                <section id="summaryStats" class="hidden grid grid-cols-4 lg:grid-cols-8 gap-1 md:gap-4 text-center my-2 md:my-0">
-            <!-- Summary boxes injected here -->
+          <article class="analyzer-panel glass-panel" id="value-panel">
+            <header class="analyzer-panel-header">
+              <div>
+                <h2>Total Roster Value</h2>
+                <p>KTC distribution by position for every team.</p>
+              </div>
+            </header>
+            <div class="analyzer-panel-body">
+              <div class="chart-container analyzer-chart">
+                <canvas id="overallValueChart" aria-label="Total roster value comparison" role="img"></canvas>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <section class="analyzer-panel glass-panel analyzer-radar-section">
+          <header class="analyzer-panel-header">
+            <div>
+              <h2>Positional Strength</h2>
+              <p>Compare your top duo at each position against the league average.</p>
+            </div>
+          </header>
+          <div class="analyzer-panel-body analyzer-panel-body--stacked">
+            <div class="chart-container analyzer-chart analyzer-chart--radar">
+              <canvas id="radarChart" aria-label="Positional strength radar" role="img"></canvas>
+            </div>
+            <div class="analyzer-standings" aria-live="polite">
+              <div class="analyzer-standings-header">
+                <h3>League Standings</h3>
+                <p>Wins, losses, and fantasy points scored.</p>
+              </div>
+              <div class="analyzer-standings-table-wrapper">
+                <table class="analyzer-table" aria-describedby="analyzer-standings">
+                  <thead>
+                    <tr>
+                      <th scope="col">Team</th>
+                      <th scope="col">Record</th>
+                      <th scope="col">PF</th>
+                      <th scope="col">PA</th>
+                    </tr>
+                  </thead>
+                  <tbody id="standingsTableBody"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
         </section>
 
-        <!-- Loading Indicator -->
-        <div id="loading" class="hidden text-center py-8">
-            <p class="text-2xl animate-pulse">Analyzing cosmic data streams...</p>
-        </div>
-
-        <!-- Main Content -->
-        <section id="infographicContent" class="hidden space-y-6">
-            <!-- Top Level Charts -->
-            <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Starting Lineup Value</h2>
-                    <div class="chart-container">
-                        <canvas id="startersValueChart"></canvas>
-                    </div>
-                </div>
-                <div class="glass-panel p-2">
-                    <h2 class="text-2xl text-center mb-4">Overall Team Value</h2>
-                    <div class="chart-container">
-                        <canvas id="overallValueChart"></canvas>
-                    </div>
-                </div>
-            </section>
-            
-            <!-- Radar Chart -->
-            <section class="glass-panel p-2">
-                <h2 class="text-2xl text-center mb-4">Positional Strength</h2>
-                <div class="chart-container">
-                    <canvas id="radarChart"></canvas>
-                </div>
-            </section>
-
-            <!-- Detailed Starter Rankings -->
-            <section class="glass-panel p-6">
-                <h2 class="text-2xl text-center mb-6">Starting Position Power Grid</h2>
-                <div id="starterRankingsGrid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-                    <!-- Grid items will be injected here by JavaScript -->
-                </div>
-            </section>
+        <section class="analyzer-panel glass-panel analyzer-leaderboard-panel">
+          <header class="analyzer-panel-header">
+            <div>
+              <h2>League Leaders</h2>
+              <p>Top 10 total fantasy scorers by position with team ownership.</p>
+            </div>
+            <div class="analyzer-filter-group" role="tablist" aria-label="Position filters">
+              <button type="button" class="filter-chip active" data-pos="QB" role="tab" aria-selected="true">QB</button>
+              <button type="button" class="filter-chip" data-pos="RB" role="tab" aria-selected="false">RB</button>
+              <button type="button" class="filter-chip" data-pos="WR" role="tab" aria-selected="false">WR</button>
+              <button type="button" class="filter-chip" data-pos="TE" role="tab" aria-selected="false">TE</button>
+            </div>
+          </header>
+          <div class="analyzer-panel-body">
+            <div class="analyzer-leaderboard">
+              <table class="analyzer-table" aria-live="polite">
+                <thead>
+                  <tr>
+                    <th scope="col" class="w-12">Rank</th>
+                    <th scope="col">Player</th>
+                    <th scope="col" class="w-20">NFL</th>
+                    <th scope="col">Owner</th>
+                    <th scope="col" class="w-24">Total FPTS</th>
+                    <th scope="col" class="w-20">PPG</th>
+                  </tr>
+                </thead>
+                <tbody id="leaderboardTableBody"></tbody>
+              </table>
+            </div>
+          </div>
         </section>
-    </div>
-        </main>
-    </div>
-
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const params = new URLSearchParams(window.location.search);
-            const username = params.get('username');
-            const leagueId = params.get('leagueId');
-
-            // --- DOM Elements ---
-            const usernameInput = document.getElementById('usernameInput');
-            const leagueSelect = document.getElementById('leagueSelect');
-            const loadingIndicator = document.getElementById('loading');
-            const infographicContent = document.getElementById('infographicContent');
-            const starterRankingsGrid = document.getElementById('starterRankingsGrid');
-            const summaryStats = document.getElementById('summaryStats');
-
-
-            // --- Chart instances ---
-            let overallChart, startersChart, radarChart;
-
-            // --- State ---
-            let state = {
-                userId: null,
-                leagues: [],
-                players: {},
-                ktcOneQb: {},
-                ktcSflx: {},
-                currentLeagueId: null,
-                isSuperflex: false,
-                cache: {}
-            };
-
-            const POS_COLORS = {
-                QB: 'rgba(255, 58, 117, 0.8)',
-                RB: 'rgba(0, 235, 199, 0.8)',
-                WR: 'rgba(88, 167, 255, 0.8)',
-                TE: 'rgba(180, 105, 255, 0.8)',
-                FLEX: 'rgba(255, 127, 80, 0.8)', // Coral
-                SUPER_FLEX: 'rgba(220, 220, 220, 0.8)', // Silver
-                Picks: 'rgba(255, 199, 0, 0.8)'
-            };
-
-
-            // --- Event Listeners ---
-            usernameInput.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') {
-                    handleFetchData();
-                }
-            });
-            leagueSelect.addEventListener('change', () => {
-                if (leagueSelect.value) {
-                    analyzeLeague(leagueSelect.value);
-                }
-            });
-
-            if (username) {
-                usernameInput.value = username;
-                handleFetchData();
-            }
-
-            async function handleFetchData() {
-                const username = usernameInput.value.trim();
-                if (!username) {
-                    alert('Please enter a Sleeper username.');
-                    return;
-                }
-
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                summaryStats.classList.add('hidden');
-
-                try {
-                    // Fetch all initial data concurrently
-                    await Promise.all([
-                        fetchSleeperPlayers(),
-                        fetchKTCData()
-                    ]);
-                    
-                    await fetchUserAndLeagues(username);
-
-                    if (state.leagues.length > 0) {
-                        if (leagueId) {
-                            const leagueExists = state.leagues.some(l => l.league_id === leagueId);
-                            if (leagueExists) {
-                                leagueSelect.value = leagueId;
-                                await analyzeLeague(leagueId);
-                            } else {
-                                alert('The specified league was not found for this user.');
-                                setLoading(false);
-                            }
-                        } else {
-                            // Auto-select and analyze the first league
-                            leagueSelect.selectedIndex = 1;
-                            await analyzeLeague(state.leagues[0].league_id);
-                        }
-                    }
-                } catch (error) {
-                    console.error('Error fetching data:', error);
-                    alert(`An error occurred: ${error.message}`);
-                } finally {
-                    setLoading(false);
-                }
-            }
-
-            // --- Data Fetching ---
-            async function fetchWithCache(url) {
-                if (state.cache[url]) return state.cache[url];
-                const response = await fetch(url);
-                if (!response.ok) throw new Error(`API request failed: ${response.statusText}`);
-                const data = await response.json();
-                state.cache[url] = data;
-                return data;
-            }
-
-            async function fetchSleeperPlayers() {
-                if (Object.keys(state.players).length > 0) return;
-                state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
-            }
-
-            async function fetchKTCData() {
-                if (Object.keys(state.ktcOneQb).length > 0) return;
-                const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
-                try {
-                    const [oneQbCsv, sflxCsv] = await Promise.all([
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_1QB`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch 1QB KTC data: ' + res.statusText);
-                            return res.text();
-                        }),
-                        fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=KTC_SFLX`).then(res => {
-                            if (!res.ok) throw new Error('Failed to fetch SFLX KTC data: ' + res.statusText);
-                            return res.text();
-                        })
-                    ]);
-                    state.ktcOneQb = parseSheetData(oneQbCsv);
-                    state.ktcSflx = parseSheetData(sflxCsv);
-                } catch (error) {
-                     console.error("KTC Fetch Error:", error);
-                     throw new Error("Could not retrieve KTC valuation data. The proxy service may be down. Please try again later.");
-                }
-            }
-            
-            function parseSheetData(csvText) {
-                const dataMap = {};
-                const lines = csvText.split(/\r?\n/).filter(line => line.trim().length > 0);
-                if (lines.length === 0) return dataMap;
-
-                const parseLine = (line) => {
-                    const result = [];
-                    let current = '';
-                    let inQuotes = false;
-                    const sanitized = line.replace(/\r$/, '');
-
-                    for (let i = 0; i < sanitized.length; i++) {
-                        const char = sanitized[i];
-                        if (inQuotes) {
-                            if (char === '"') {
-                                if (sanitized[i + 1] === '"') {
-                                    current += '"';
-                                    i++;
-                                } else {
-                                    inQuotes = false;
-                                }
-                            } else {
-                                current += char;
-                            }
-                        } else if (char === '"') {
-                            inQuotes = true;
-                        } else if (char === ',') {
-                            result.push(current.trim());
-                            current = '';
-                        } else {
-                            current += char;
-                        }
-                    }
-                    result.push(current.trim());
-                    return result;
-                };
-
-                const normalize = (header) => header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
-                const headers = parseLine(lines[0]).map(cell => cell.trim());
-                const headerIndex = new Map();
-                headers.forEach((header, idx) => {
-                    headerIndex.set(normalize(header), idx);
-                });
-
-                const getValue = (columns, names) => {
-                    const keys = Array.isArray(names) ? names : [names];
-                    for (const name of keys) {
-                        const idx = headerIndex.get(normalize(name));
-                        if (idx !== undefined && columns[idx] !== undefined) {
-                            return columns[idx].trim();
-                        }
-                    }
-                    return '';
-                };
-
-                const toInt = (value) => {
-                    const num = parseInt(value, 10);
-                    return Number.isNaN(num) ? null : num;
-                };
-
-                lines.slice(1).forEach(line => {
-                    const columns = parseLine(line);
-                    if (!columns.length) return;
-
-                    const pos = getValue(columns, 'POS');
-                    const sleeperId = getValue(columns, 'SLPR_ID');
-                    const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
-
-                    if (pos === 'RDP') {
-                        const pickName = getValue(columns, 'PLAYER NAME');
-                        if (pickName) {
-                            dataMap[pickName] = { ktc: ktcValue };
-                        }
-                        return;
-                    }
-
-                    if (!sleeperId || sleeperId === 'NA') return;
-
-                    dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
-                });
-
-                return dataMap;
-            }
-
-            async function fetchUserAndLeagues(username) {
-                const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
-                if (!user || !user.user_id) throw new Error('Sleeper user not found.');
-                state.userId = user.user_id;
-
-                const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${new Date().getFullYear()}`);
-                if (!leagues || leagues.length === 0) throw new Error('No active leagues found for this user in the current season.');
-                state.leagues = leagues.sort((a,b) => a.name.localeCompare(b.name));
-
-                populateLeagueSelect(state.leagues);
-            }
-
-            async function analyzeLeague(leagueId) {
-                setLoading(true);
-                infographicContent.classList.add('hidden');
-                state.currentLeagueId = leagueId;
-
-                const leagueInfo = state.leagues.find(l => l.league_id === leagueId);
-                const qbSlots = leagueInfo.roster_positions.filter(p => p === 'QB').length;
-                const superflexSlots = leagueInfo.roster_positions.filter(p => p === 'SUPER_FLEX').length;
-                state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
-
-                const [rosters, users, tradedPicks] = await Promise.all([
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
-                    fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`)
-                ]);
-
-                const teams = processLeagueData(rosters, users, tradedPicks, leagueInfo);
-                
-                infographicContent.classList.remove('hidden');
-                summaryStats.classList.remove('hidden');
-                
-                renderSummaryStats(teams);
-                renderCharts(teams);
-                renderRadarChart(teams);
-                renderStarterGrid(teams, leagueInfo);
-
-                setLoading(false);
-            }
-
-            function processLeagueData(rosters, users, tradedPicks, leagueInfo) {
-                const userMap = users.reduce((acc, user) => ({ ...acc, [user.user_id]: user }), {});
-
-                return rosters.map(roster => {
-                    const owner = userMap[roster.owner_id];
-                    const teamName = owner?.display_name || `Team ${roster.roster_id}`;
-                    
-                    let topPlayer = { name: 'N/A', ktc: 0 };
-                    const allPlayers = (roster.players || []).map(pId => {
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        if (ktc > topPlayer.ktc) {
-                            topPlayer = { name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown', ktc };
-                        }
-                        return { id: pId, pos: playerInfo?.position, ktc };
-                    }).sort((a,b) => b.ktc - a.ktc);
-
-                    const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
-                    allPlayers.forEach(p => {
-                        if (overallPositional.hasOwnProperty(p.pos)) {
-                            overallPositional[p.pos] += p.ktc;
-                        }
-                    });
-                    
-                    getOwnedPicks(roster.roster_id, rosters, tradedPicks, leagueInfo).forEach(p => {
-                        overallPositional.Picks += getKtcValue(p.label);
-                    });
-
-                    const startersPositional = { QB: 0, RB: 0, WR: 0, TE: 0, FLEX: 0, 'SUPER_FLEX': 0 };
-                    const startersPlayerDetails = { QB: [], RB: [], WR: [], TE: [], FLEX: [], 'SUPER_FLEX': [] };
-                    const startersValueByPosition = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                    const starterIds = roster.starters || [];
-                    const rosterPositions = leagueInfo.roster_positions;
-                    starterIds.forEach((pId, index) => {
-                        const slot = rosterPositions[index];
-                        const playerInfo = state.players[pId];
-                        const ktc = getKtcValue(pId);
-                        
-                        // For stacked bar chart
-                        if (startersPositional.hasOwnProperty(slot)) {
-                            startersPositional[slot] += ktc;
-                            startersPlayerDetails[slot].push({
-                                name: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name[0]}. ${playerInfo.last_name}` : 'Unknown',
-                                ktc: ktc
-                            });
-                        }
-
-                        // For summary rank calculation
-                        if (playerInfo && startersValueByPosition.hasOwnProperty(playerInfo.position)) {
-                            startersValueByPosition[playerInfo.position] += ktc;
-                        }
-                    });
-                    
-                    const totalValue = Object.values(overallPositional).reduce((a, b) => a + b, 0);
-
-                    return {
-                        teamName,
-                        totalValue,
-                        startersValue: Object.values(startersPositional).reduce((a,b) => a+b, 0),
-                        overallPositional,
-                        startersPositional,
-                        startersPlayerDetails,
-                        startersValueByPosition,
-                        roster,
-                        topPlayer,
-                        allPlayers,
-                        isUserTeam: roster.owner_id === state.userId
-                    };
-                }).sort((a,b) => b.totalValue - a.totalValue);
-            }
-
-            function getOwnedPicks(rosterId, allRosters, tradedPicks, leagueInfo) {
-                const currentYear = new Date().getFullYear();
-                const all_picks = [];
-
-                // 1. Generate all original picks for every team for the next 4 years
-                for (const r of allRosters) {
-                    for (let i = 1; i <= 4; i++) {
-                        const season = currentYear + i;
-                        for (let round = 1; round <= leagueInfo.settings.draft_rounds; round++) {
-                            all_picks.push({
-                                season: season.toString(),
-                                round: round,
-                                roster_id: r.roster_id, // Original owner
-                                owner_id: r.roster_id    // Current owner (by default)
-                            });
-                        }
-                    }
-                }
-
-                // 2. Account for trades
-                tradedPicks.forEach(trade => {
-                    const pickIndex = all_picks.findIndex(p =>
-                        p.season === trade.season &&
-                        p.round === trade.round &&
-                        p.roster_id === trade.roster_id
-                    );
-                    if (pickIndex !== -1) {
-                        all_picks[pickIndex].owner_id = trade.owner_id;
-                    }
-                });
-
-                // 3. Filter for picks owned by the current roster
-                return all_picks
-                    .filter(p => p.owner_id === rosterId)
-                    .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
-                    .map(p => ({ ...p, label: `${p.season} Mid ${ordinal(p.round)}` }));
-            }
-
-            // --- UI Rendering ---
-            function renderSummaryStats(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) {
-                    summaryStats.classList.add('hidden');
-                    return;
-                }
-
-                const sortedByStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                
-                const totalRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-                const starterRank = sortedByStarters.findIndex(t => t.isUserTeam) + 1;
-
-                const positionsToRank = ['QB', 'RB', 'WR', 'TE'];
-                const positionalRanks = {};
-                positionsToRank.forEach(pos => {
-                    const sorted = [...teams].sort((a,b) => b.startersValueByPosition[pos] - a.startersValueByPosition[pos]);
-                    positionalRanks[pos] = sorted.findIndex(t => t.isUserTeam) + 1;
-                });
-
-                summaryStats.innerHTML = `
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Overall Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(totalRank, teams.length)}">${totalRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters KTC</p>
-                        <p class="text-lg font-bold">${userTeam.startersValue.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Starters Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(starterRank, teams.length)}">${starterRank}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">Top Player</p>
-                        <p class="text-sm font-bold truncate">${userTeam.topPlayer.name}</p>
-                        <p class="text-[10px] text-purple-400">${userTeam.topPlayer.ktc.toLocaleString()}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">QB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.QB, teams.length)}">${positionalRanks.QB}/${teams.length}</p>
-                    </div>
-                    <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">RB Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.RB, teams.length)}">${positionalRanks.RB}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">WR Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.WR, teams.length)}">${positionalRanks.WR}/${teams.length}</p>
-                    </div>
-                     <div class="glass-panel p-1 rounded-lg">
-                        <p class="text-[10px] text-gray-400">TE Rank</p>
-                        <p class="text-lg font-bold" style="color: ${getRankColor(positionalRanks.TE, teams.length)}">${positionalRanks.TE}/${teams.length}</p>
-                    </div>
-                `;
-            }
-            
-            function renderCharts(teams) {
-                const labels = teams.map(t => {
-                    const name = t.teamName;
-                    return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                });
-
-                // Overall Chart
-                const overallDatasets = Object.keys(teams[0].overallPositional).map(pos => ({
-                    label: pos,
-                    data: teams.map(t => t.overallPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                if(overallChart) overallChart.destroy();
-                const overallMaxKtc = Math.max(...teams.map(t => t.totalValue));
-                overallChart = new Chart(document.getElementById('overallValueChart'), {
-                    type: 'bar',
-                    data: { labels, datasets: overallDatasets },
-                    options: chartOptions(null, overallMaxKtc)
-                });
-
-                // Starters Chart
-                const sortedStarters = [...teams].sort((a, b) => b.startersValue - a.startersValue);
-                const startersLabels = sortedStarters.map(t => t.teamName);
-                const startersDatasets = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].map(pos => ({
-                    label: pos,
-                    data: sortedStarters.map(t => t.startersPositional[pos]),
-                    backgroundColor: POS_COLORS[pos]
-                }));
-                
-                const startersMaxKtc = Math.max(...sortedStarters.map(t => t.startersValue));
-
-                if(startersChart) startersChart.destroy();
-                startersChart = new Chart(document.getElementById('startersValueChart'), {
-                    type: 'bar',
-                    data: {
-                        labels: sortedStarters.map(t => {
-                            const name = t.teamName;
-                            return name.length > 11 ? name.substring(0, 11) + '…' : name;
-                        }),
-                        datasets: startersDatasets
-                    },
-                    options: chartOptions(sortedStarters, startersMaxKtc) // Pass sorted teams and max value
-                });
-            }
-
-            function renderRadarChart(teams) {
-                const userTeam = teams.find(t => t.isUserTeam);
-                if (!userTeam) return;
-
-                const leagueAverages = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const userValues = { QB: 0, RB: 0, WR: 0, TE: 0 };
-                const positions = ['QB', 'RB', 'WR', 'TE'];
-
-                positions.forEach(pos => {
-                    let totalLeagueKTC = 0;
-                    teams.forEach(team => {
-                        const topTwoPlayers = team.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                        totalLeagueKTC += topTwoPlayers.reduce((sum, player) => sum + player.ktc, 0);
-                    });
-                    leagueAverages[pos] = totalLeagueKTC / teams.length;
-
-                    const userTopTwo = userTeam.allPlayers.filter(p => p.pos === pos).slice(0, 2);
-                    userValues[pos] = userTopTwo.reduce((sum, player) => sum + player.ktc, 0);
-                });
-                
-                if(radarChart) radarChart.destroy();
-                radarChart = new Chart(document.getElementById('radarChart'), {
-                    type: 'radar',
-                    data: {
-                        labels: positions,
-                        datasets: [
-                            {
-                                label: 'Your Team (Top 2)',
-                                data: Object.values(userValues),
-                                fill: true,
-                                backgroundColor: 'rgba(118, 109, 255, 0.4)',
-                                borderColor: 'rgba(118, 109, 255, 1)',
-                                pointBackgroundColor: 'rgba(118, 109, 255, 1)',
-                                pointBorderColor: '#fff',
-                            },
-                            {
-                                label: 'League Average (Top 2)',
-                                data: Object.values(leagueAverages),
-                                fill: true,
-                                backgroundColor: 'rgba(66, 194, 255, 0.4)',
-                                borderColor: 'rgba(66, 194, 255, 1)',
-                                pointBackgroundColor: 'rgba(66, 194, 255, 1)',
-                                pointBorderColor: '#fff',
-                            }
-                        ]
-                    },
-                    options: {
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        elements: {
-                            line: {
-                                borderWidth: 3
-                            }
-                        },
-                        scales: {
-                            r: {
-                                angleLines: { color: 'rgba(255, 255, 255, 0.2)' },
-                                grid: { color: 'rgba(255, 255, 255, 0.2)' },
-                                pointLabels: {
-                                    font: { size: 14, family: "'Orbitron', sans-serif" },
-                                    color: '#EAEBF0'
-                                },
-                                ticks: {
-                                    color: '#EAEBF0',
-                                    backdropColor: 'rgba(0,0,0,0.5)',
-                                    font: { family: "'Roboto', sans-serif" }
-                                }
-                            }
-                        },
-                        plugins: {
-                             legend: {
-                                position: 'top',
-                                labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                            }
-                        }
-                    }
-                });
-            }
-
-            function renderStarterGrid(teams, leagueInfo) {
-                starterRankingsGrid.innerHTML = '';
-
-                const starterPositions = {};
-                leagueInfo.roster_positions.forEach(pos => {
-                    if (['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'].includes(pos)) {
-                        starterPositions[pos] = (starterPositions[pos] || 0) + 1;
-                    }
-                });
-
-                Object.entries(starterPositions).forEach(([slotPosition, count]) => {
-                    for (let i = 0; i < count; i++) {
-                        const slotIndex = i + 1;
-                        const slotData = [];
-
-                        teams.forEach(team => {
-                            const starters = team.roster.starters || [];
-                            const positions = leagueInfo.roster_positions;
-                            let playerFound = false;
-                            let currentSlotCount = 0;
-
-                            for (let j = 0; j < starters.length; j++) {
-                                if (positions[j] === slotPosition) {
-                                    currentSlotCount++;
-                                    if (currentSlotCount === slotIndex) {
-                                        const playerId = starters[j];
-                                        const playerInfo = state.players[playerId];
-                                        const ktcValue = getKtcValue(playerId);
-                                        slotData.push({
-                                            teamName: team.teamName,
-                                            playerName: (playerInfo && playerInfo.first_name) ? `${playerInfo.first_name} ${playerInfo.last_name}` : 'Empty Slot',
-                                            ktcValue: ktcValue,
-                                        });
-                                        playerFound = true;
-                                        break;
-                                    }
-                                }
-                            }
-                             if (!playerFound) {
-                                slotData.push({ teamName: team.teamName, playerName: 'Empty Slot', ktcValue: 0 });
-                            }
-                        });
-
-                        slotData.sort((a, b) => b.ktcValue - a.ktcValue);
-
-                        const gridItem = document.createElement('div');
-                        gridItem.className = 'glass-panel p-3';
-
-                        let content = `<h3 class="text-lg font-bold text-center mb-2">${slotPosition.replace('_', ' ')} ${slotIndex}</h3><ul>`;
-                        slotData.forEach((data, index) => {
-                            const rank = index + 1;
-                            const color = getRankColor(rank, teams.length);
-                            content += `
-                                <li class="flex justify-between items-center text-xs py-0.5 border-b border-gray-800/50 gap-2">
-                                    <div class="flex items-center gap-2 w-3/5 min-w-0">
-                                        <span class="font-bold w-6 flex-shrink-0" style="color: ${color};">${rank}.</span>
-                                        <span class="truncate">${data.teamName}</span>
-                                    </div>
-                                    <div class="text-right flex-shrink-0 w-2/5">
-                                        <span class="font-semibold" style="color: ${color};">${data.ktcValue.toLocaleString()}</span>
-                                        <p class="text-xs text-gray-500 truncate">${data.playerName}</p>
-                                    </div>
-                                </li>
-                            `;
-                        });
-                        content += '</ul>';
-                        gridItem.innerHTML = content;
-                        starterRankingsGrid.appendChild(gridItem);
-                    }
-                });
-            }
-
-            // --- Charting ---
-            function chartOptions(teamsDataForTooltip = null, maxKtc = 0) {
-                const tooltipOptions = {
-                     backgroundColor: 'rgba(13, 14, 27, 0.9)',
-                     titleFont: { family: "'Orbitron', sans-serif", size: 16 },
-                     bodyFont: { family: "'Roboto', sans-serif", size: 12 },
-                     footerFont: { family: "'Roboto', sans-serif", weight: 'bold' },
-                     borderColor: 'rgba(118, 109, 255, 0.5)',
-                     borderWidth: 1,
-                     padding: 10,
-                     callbacks: {}
-                };
-
-                if (teamsDataForTooltip) {
-                    tooltipOptions.callbacks.footer = (tooltipItems) => {
-                        const teamIndex = tooltipItems[0].dataIndex;
-                        const positionLabel = tooltipItems[0].dataset.label;
-                        const teamData = teamsDataForTooltip[teamIndex];
-                        
-                        if (teamData && teamData.startersPlayerDetails && teamData.startersPlayerDetails[positionLabel]) {
-                            const players = teamData.startersPlayerDetails[positionLabel];
-                            return players
-                                .sort((a, b) => b.ktc - a.ktc)
-                                .slice(0, 3)
-                                .map(p => `${p.name}: ${p.ktc.toLocaleString()}`)
-                                .join('\n');
-                        }
-                        return '';
-                    };
-                }
-
-                return {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    indexAxis: 'y',
-                    layout: {
-                        padding: {
-                            left: 0,
-                            right: 5 
-                        }
-                    },
-                    scales: {
-                        x: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif"
-                                 },
-                                 maxRotation: 45,
-                                 minRotation: 45,
-                            },
-                            grid: { color: 'rgba(255, 255, 255, 0.1)' },
-                            max: Math.ceil(maxKtc / 10000) * 10000,
-                        },
-                        y: {
-                            stacked: true,
-                            ticks: { 
-                                color: '#EAEBF0', 
-                                font: { 
-                                    family: "'Roboto', sans-serif",
-                                    size: 10
-                                 },
-                                 callback: function(value, index, values) {
-                                    const label = this.getLabelForValue(value);
-                                    // The label is already truncated before being passed to the chart data
-                                    return label;
-                                }
-                            },
-                            grid: { display: false }
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            position: 'bottom',
-                            labels: { color: '#EAEBF0', font: { family: "'Roboto', sans-serif" } }
-                        },
-                        tooltip: tooltipOptions
-                    }
-                };
-            }
-            
-            // --- KTC & Formatting Helpers ---
-            function getKtcValue(id) {
-                const ktcSource = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
-                return ktcSource[id]?.ktc || 0;
-            }
-
-            function ordinal(i) {
-                const j = i % 10, k = i % 100;
-                if (j === 1 && k !== 11) return i + "st";
-                if (j === 2 && k !== 12) return i + "nd";
-                if (j === 3 && k !== 13) return i + "rd";
-                return i + "th";
-            }
-
-            function getRankColor(rank, total) {
-                const percentile = (total - rank + 1) / total;
-                if (percentile >= 0.8) return '#00EBC7'; // Top 20%
-                if (percentile >= 0.6) return '#58A7FF';
-                if (percentile >= 0.4) return '#EAEBF0';
-                if (percentile >= 0.2) return '#FF7F50';
-                return '#FF3A75'; // Bottom 20%
-            }
-
-            // --- UI Helpers ---
-            function populateLeagueSelect(leagues) {
-                leagueSelect.innerHTML = '<option value="">Select a league...</option>';
-                leagues.forEach(league => {
-                    const option = document.createElement('option');
-                    option.value = league.league_id;
-                    option.textContent = league.name;
-                    leagueSelect.appendChild(option);
-                });
-                leagueSelect.disabled = false;
-            }
-
-            function setLoading(isLoading) {
-                if (isLoading) {
-                    loadingIndicator.classList.remove('hidden');
-                } else {
-                    loadingIndicator.classList.add('hidden');
-                }
-            }
-        });
-    </script>
-    <script defer src="../scripts/app.js?v=20250826235225"></script>
+      </section>
+    </main>
+  </div>
+
+  <script src="../scripts/analyzer.js"></script>
+  <script defer src="../scripts/app.js?v=20250826235225"></script>
 </body>
 </html>
-
-
-

--- a/DHP2_DeployDraft1.2/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.2/scripts/analyzer.js
@@ -1,0 +1,1164 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', () => {
+    if (document.body.dataset.page !== 'analyzer') {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const initialUsername = params.get('username');
+    const initialLeagueId = params.get('leagueId');
+
+    const elements = {
+      usernameInput: document.getElementById('usernameInput'),
+      leagueSelect: document.getElementById('leagueSelect'),
+      loading: document.getElementById('loading'),
+      summaryStats: document.getElementById('summaryStats'),
+      content: document.getElementById('infographicContent'),
+      lineupToggle: document.querySelectorAll('#lineup-panel .toggle-option'),
+      startersCanvas: document.getElementById('startersValueChart'),
+      overallCanvas: document.getElementById('overallValueChart'),
+      radarCanvas: document.getElementById('radarChart'),
+      standingsBody: document.getElementById('standingsTableBody'),
+      leaderboardBody: document.getElementById('leaderboardTableBody'),
+      leaderboardFilters: document.querySelectorAll('.analyzer-filter-group .filter-chip'),
+      activeUsername: document.getElementById('activeUsername'),
+      activeLeague: document.getElementById('activeLeague'),
+    };
+
+    const SLOT_ORDER = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
+    const SLOT_LABELS = {
+      QB: 'QB',
+      RB: 'RB',
+      WR: 'WR',
+      TE: 'TE',
+      FLEX: 'Flex',
+      SUPER_FLEX: 'Superflex',
+      Picks: 'Draft Picks',
+    };
+
+    const SLOT_ALIASES = {
+      'WR/RB': 'FLEX',
+      'RB/WR': 'FLEX',
+      'WR/RB/TE': 'FLEX',
+      'RB/WR/TE': 'FLEX',
+      'W/R/T': 'FLEX',
+      'FLEX': 'FLEX',
+      'SUPER_FLEX': 'SUPER_FLEX',
+      'QB/RB/WR/TE': 'SUPER_FLEX',
+      'Q/W/R/T': 'SUPER_FLEX',
+    };
+
+    const POSITION_ORDER = ['QB', 'RB', 'WR', 'TE'];
+
+    const LINEUP_COLORS = {
+      QB: ['rgba(255, 58, 117, 0.85)', 'rgba(255, 58, 117, 0.45)'],
+      RB: ['rgba(0, 235, 199, 0.9)', 'rgba(0, 235, 199, 0.45)'],
+      WR: ['rgba(88, 167, 255, 0.9)', 'rgba(88, 167, 255, 0.45)'],
+      TE: ['rgba(180, 105, 255, 0.85)', 'rgba(180, 105, 255, 0.45)'],
+      FLEX: ['rgba(255, 127, 80, 0.85)', 'rgba(255, 127, 80, 0.45)'],
+      SUPER_FLEX: ['rgba(220, 220, 220, 0.85)', 'rgba(220, 220, 220, 0.35)'],
+      Picks: ['rgba(255, 199, 0, 0.85)', 'rgba(255, 199, 0, 0.45)'],
+    };
+
+    const state = {
+      userId: null,
+      leagues: [],
+      players: {},
+      ktcOneQb: {},
+      ktcSflx: {},
+      playerStats: {},
+      playerStatsSeason: null,
+      currentLeagueId: null,
+      currentLineupMetric: 'value',
+      isSuperflex: false,
+      cache: {},
+      charts: {
+        lineup: null,
+        overall: null,
+        radar: null,
+      },
+      lineupData: null,
+      teams: [],
+      leaderboards: { QB: [], RB: [], WR: [], TE: [] },
+      activeLeaderboard: 'QB',
+    };
+
+    elements.usernameInput?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        handleFetchData();
+      }
+    });
+
+    elements.leagueSelect?.addEventListener('change', () => {
+      const leagueId = elements.leagueSelect.value;
+      if (leagueId) {
+        analyzeLeague(leagueId);
+        updateActiveLeagueLabel();
+      }
+    });
+
+    elements.lineupToggle.forEach((button) => {
+      button.addEventListener('click', () => {
+        const metric = button.dataset.metric;
+        if (!metric || metric === state.currentLineupMetric) return;
+        state.currentLineupMetric = metric;
+        elements.lineupToggle.forEach((btn) => {
+          const isActive = btn.dataset.metric === metric;
+          btn.classList.toggle('active', isActive);
+          btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+        updateLineupChart();
+      });
+    });
+
+    elements.leaderboardFilters.forEach((button) => {
+      button.addEventListener('click', () => {
+        const pos = button.dataset.pos;
+        if (!pos || pos === state.activeLeaderboard) return;
+        state.activeLeaderboard = pos;
+        elements.leaderboardFilters.forEach((btn) => {
+          const isActive = btn.dataset.pos === pos;
+          btn.classList.toggle('active', isActive);
+          btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        });
+        renderLeagueLeaders();
+      });
+    });
+
+    if (initialUsername) {
+      elements.usernameInput.value = initialUsername;
+      setActiveUsername(initialUsername);
+      handleFetchData(initialLeagueId);
+    }
+
+    async function handleFetchData(targetLeagueId) {
+      const username = elements.usernameInput.value.trim();
+      if (!username) {
+        alert('Please enter a Sleeper username.');
+        return;
+      }
+
+      setLoading(true);
+      setActiveUsername(username);
+      hideContent();
+
+      try {
+        await Promise.all([fetchSleeperPlayers(), fetchKTCData()]);
+        await fetchUserAndLeagues(username);
+
+        if (state.leagues.length === 0) {
+          throw new Error('No active leagues found for this user in the current season.');
+        }
+
+        if (targetLeagueId) {
+          const target = state.leagues.find((league) => league.league_id === targetLeagueId);
+          if (target) {
+            elements.leagueSelect.value = targetLeagueId;
+            updateActiveLeagueLabel();
+            await analyzeLeague(targetLeagueId);
+            return;
+          }
+        }
+
+        elements.leagueSelect.selectedIndex = 1;
+        updateActiveLeagueLabel();
+        await analyzeLeague(state.leagues[0].league_id);
+      } catch (error) {
+        console.error('Analyzer fetch error:', error);
+        alert(`An error occurred while loading data: ${error.message}`);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    function hideContent() {
+      elements.content.classList.add('hidden');
+      elements.summaryStats.classList.add('hidden');
+    }
+
+    function setActiveUsername(username) {
+      if (elements.activeUsername) {
+        elements.activeUsername.textContent = username ? `@${username}` : '—';
+      }
+    }
+
+    function updateActiveLeagueLabel() {
+      if (!elements.activeLeague) return;
+      const selectedId = elements.leagueSelect.value;
+      if (!selectedId) {
+        elements.activeLeague.textContent = 'Select a league...';
+        return;
+      }
+      const league = state.leagues.find((entry) => entry.league_id === selectedId);
+      elements.activeLeague.textContent = league ? league.name : 'Select a league...';
+    }
+
+    async function fetchWithCache(url) {
+      if (state.cache[url]) {
+        return state.cache[url];
+      }
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+      }
+      const data = await response.json();
+      state.cache[url] = data;
+      return data;
+    }
+
+    async function fetchSleeperPlayers() {
+      if (Object.keys(state.players).length > 0) return;
+      state.players = await fetchWithCache('https://api.sleeper.app/v1/players/nfl');
+    }
+
+    async function fetchKTCData() {
+      if (Object.keys(state.ktcOneQb).length > 0) return;
+
+      const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
+      const parseCsvData = async (sheet) => {
+        const response = await fetch(`https://docs.google.com/spreadsheets/d/${GOOGLE_SHEET_ID}/gviz/tq?tqx=out:csv&sheet=${sheet}`);
+        if (!response.ok) throw new Error('Failed to load KTC data.');
+        return response.text();
+      };
+
+      const [oneQbCsv, sflxCsv] = await Promise.all([
+        parseCsvData('KTC_1QB'),
+        parseCsvData('KTC_SFLX'),
+      ]);
+
+      state.ktcOneQb = parseKtcCsv(oneQbCsv);
+      state.ktcSflx = parseKtcCsv(sflxCsv);
+    }
+
+    function parseKtcCsv(csvText) {
+      if (!csvText) return {};
+      const lines = csvText.split('\n').filter(Boolean);
+      if (lines.length <= 1) return {};
+
+      const parseLine = (line) => {
+        const result = [];
+        let current = '';
+        let inQuotes = false;
+        for (let i = 0; i < line.length; i += 1) {
+          const char = line[i];
+          if (inQuotes) {
+            if (char === '"' && line[i + 1] === '"') {
+              current += '"';
+              i += 1;
+            } else if (char === '"') {
+              inQuotes = false;
+            } else {
+              current += char;
+            }
+          } else if (char === '"') {
+            inQuotes = true;
+          } else if (char === ',') {
+            result.push(current.trim());
+            current = '';
+          } else {
+            current += char;
+          }
+        }
+        result.push(current.trim());
+        return result;
+      };
+
+      const normalize = (header) => header.replace(/[\u00a0\u202f]/g, ' ').trim().toUpperCase();
+      const headers = parseLine(lines[0]);
+      const headerIndex = new Map();
+      headers.forEach((header, idx) => {
+        headerIndex.set(normalize(header), idx);
+      });
+
+      const getValue = (columns, names) => {
+        const keys = Array.isArray(names) ? names : [names];
+        for (const key of keys) {
+          const index = headerIndex.get(normalize(key));
+          if (index !== undefined && columns[index] !== undefined) {
+            return columns[index].trim();
+          }
+        }
+        return '';
+      };
+
+      const toInt = (value) => {
+        const num = parseInt(value, 10);
+        return Number.isNaN(num) ? null : num;
+      };
+
+      const dataMap = {};
+      lines.slice(1).forEach((line) => {
+        const columns = parseLine(line);
+        if (!columns.length) return;
+
+        const pos = getValue(columns, 'POS');
+        const sleeperId = getValue(columns, 'SLPR_ID');
+        const ktcValue = toInt(getValue(columns, ['VALUE', 'KTC']));
+
+        if (pos === 'RDP') {
+          const pickName = getValue(columns, 'PLAYER NAME');
+          if (pickName) {
+            dataMap[pickName] = { ktc: ktcValue ?? 0 };
+          }
+          return;
+        }
+
+        if (!sleeperId || sleeperId === 'NA') return;
+        dataMap[sleeperId] = { ktc: ktcValue ?? 0 };
+      });
+
+      return dataMap;
+    }
+
+    async function fetchUserAndLeagues(username) {
+      const user = await fetchWithCache(`https://api.sleeper.app/v1/user/${username}`);
+      if (!user || !user.user_id) {
+        throw new Error('Sleeper user not found.');
+      }
+      state.userId = user.user_id;
+
+      const currentYear = new Date().getFullYear();
+      const leagues = await fetchWithCache(`https://api.sleeper.app/v1/user/${state.userId}/leagues/nfl/${currentYear}`);
+      if (!Array.isArray(leagues) || leagues.length === 0) {
+        throw new Error('No active leagues found for this user in the current season.');
+      }
+
+      state.leagues = leagues.sort((a, b) => a.name.localeCompare(b.name));
+      populateLeagueSelect(state.leagues);
+    }
+
+    async function ensurePlayerStats(season) {
+      if (state.playerStatsSeason === season && Object.keys(state.playerStats).length > 0) {
+        return;
+      }
+      const url = `https://api.sleeper.app/v1/stats/nfl/regular/${season}`;
+      const rawStats = await fetchWithCache(url);
+      state.playerStats = transformSeasonStats(rawStats);
+      state.playerStatsSeason = season;
+    }
+
+    function transformSeasonStats(rawStats) {
+      const result = {};
+      if (!rawStats) return result;
+
+      const processEntry = (playerId, stats) => {
+        if (!playerId || !stats) return;
+        const total = toNumber(stats.pts_ppr ?? stats.fpts_ppr ?? stats.fpts ?? 0);
+        const games = toNumber(stats.gp ?? stats.games_played ?? stats.gm ?? 0);
+        const ppg = games > 0 ? total / games : 0;
+        result[playerId] = {
+          total,
+          games,
+          ppg,
+        };
+      };
+
+      if (Array.isArray(rawStats)) {
+        rawStats.forEach((entry) => {
+          if (!entry) return;
+          const playerId = entry.player_id || entry.playerId || entry.id;
+          processEntry(playerId, entry);
+        });
+      } else if (typeof rawStats === 'object') {
+        Object.entries(rawStats).forEach(([playerId, stats]) => {
+          processEntry(playerId, stats);
+        });
+      }
+
+      return result;
+    }
+
+    function toNumber(value) {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    async function analyzeLeague(leagueId) {
+      try {
+        setLoading(true);
+        hideContent();
+
+        const leagueInfo = state.leagues.find((league) => league.league_id === leagueId);
+        if (!leagueInfo) throw new Error('League not found.');
+
+        state.currentLeagueId = leagueId;
+        const qbSlots = leagueInfo.roster_positions.filter((slot) => slot === 'QB').length;
+        const superflexSlots = leagueInfo.roster_positions.filter((slot) => slot === 'SUPER_FLEX').length;
+        state.isSuperflex = qbSlots > 1 || superflexSlots > 0;
+
+        await ensurePlayerStats(leagueInfo.season ?? new Date().getFullYear());
+
+        const [rosters, users, tradedPicks] = await Promise.all([
+          fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/rosters`),
+          fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/users`),
+          fetchWithCache(`https://api.sleeper.app/v1/league/${leagueId}/traded_picks`),
+        ]);
+
+        const processed = processLeagueData(rosters, users, tradedPicks, leagueInfo);
+        state.teams = processed.teams;
+        state.leaderboards = processed.leaderboards;
+        renderSummaryStats(state.teams);
+        renderLineupChart(state.teams);
+        renderOverallChart(state.teams);
+        renderRadarChart(state.teams);
+        renderStandings(state.teams);
+        renderLeagueLeaders();
+
+        elements.content.classList.remove('hidden');
+        if (!elements.summaryStats.classList.contains('hidden')) {
+          // already visible
+        } else {
+          elements.summaryStats.classList.remove('hidden');
+        }
+      } catch (error) {
+        console.error('Analyze league error:', error);
+        alert(`Failed to analyze league: ${error.message}`);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    function processLeagueData(rosters, users, tradedPicks, leagueInfo) {
+      const userMap = Array.isArray(users)
+        ? users.reduce((acc, user) => {
+            acc[user.user_id] = user;
+            return acc;
+          }, {})
+        : {};
+
+      const leaderboards = { QB: [], RB: [], WR: [], TE: [] };
+
+      const teams = (Array.isArray(rosters) ? rosters : []).map((roster) => {
+        const owner = userMap[roster.owner_id] || userMap[roster.co_owner_id];
+        const teamName = roster.metadata?.team_name || owner?.display_name || `Team ${roster.roster_id}`;
+
+        const startersBySlot = {};
+        SLOT_ORDER.forEach((slot) => {
+          startersBySlot[slot] = { value: 0, ppg: 0, players: [] };
+        });
+
+        const startersValueByPos = { QB: 0, RB: 0, WR: 0, TE: 0 };
+        const starterIds = roster.starters || [];
+        const rosterPositions = leagueInfo.roster_positions || [];
+
+        starterIds.forEach((playerId, index) => {
+          const slotRaw = rosterPositions[index] || 'BN';
+          const slot = normalizeSlot(slotRaw);
+          if (!slot) return;
+          if (!startersBySlot[slot]) {
+            startersBySlot[slot] = { value: 0, ppg: 0, players: [] };
+          }
+
+          const playerInfo = state.players[playerId];
+          const playerStats = state.playerStats[playerId] || {};
+          const ktc = getKtcValue(playerId);
+          const ppg = playerStats.ppg ?? 0;
+
+          startersBySlot[slot].value += ktc;
+          startersBySlot[slot].ppg += ppg;
+
+          const playerName = formatPlayerName(playerInfo);
+          startersBySlot[slot].players.push({ name: playerName, value: ktc, ppg });
+
+          const pos = playerInfo?.position;
+          if (pos && startersValueByPos[pos] !== undefined) {
+            startersValueByPos[pos] += ktc;
+          }
+        });
+
+        const overallPositional = { QB: 0, RB: 0, WR: 0, TE: 0, Picks: 0 };
+        const allPlayers = (roster.players || []).map((playerId) => {
+          const playerInfo = state.players[playerId];
+          const ktc = getKtcValue(playerId);
+          const pos = playerInfo?.position;
+          if (pos && overallPositional[pos] !== undefined) {
+            overallPositional[pos] += ktc;
+          }
+          return {
+            id: playerId,
+            pos,
+            ktc,
+            name: formatPlayerName(playerInfo),
+          };
+        }).sort((a, b) => b.ktc - a.ktc);
+
+        getOwnedPicks(roster.roster_id, rosters, tradedPicks, leagueInfo).forEach((pick) => {
+          overallPositional.Picks += getKtcValue(pick.label);
+        });
+
+        const totalValue = Object.values(overallPositional).reduce((sum, value) => sum + value, 0);
+        const startersValueTotal = SLOT_ORDER.reduce((sum, slot) => sum + (startersBySlot[slot]?.value ?? 0), 0);
+        const starterPpgTotal = SLOT_ORDER.reduce((sum, slot) => sum + (startersBySlot[slot]?.ppg ?? 0), 0);
+
+        const settings = roster.settings || {};
+        const wins = toNumber(settings.wins);
+        const losses = toNumber(settings.losses);
+        const ties = toNumber(settings.ties);
+        const pf = combineScore(settings.fpts, settings.fpts_decimal);
+        const pa = combineScore(settings.fpts_against, settings.fpts_against_decimal);
+        const gamesPlayed = wins + losses + ties;
+        const teamPpg = gamesPlayed > 0 ? pf / gamesPlayed : 0;
+
+        const record = ties ? `${wins}-${losses}-${ties}` : `${wins}-${losses}`;
+
+        (roster.players || []).forEach((playerId) => {
+          const playerInfo = state.players[playerId];
+          if (!playerInfo) return;
+          const pos = playerInfo.position;
+          if (!leaderboards[pos]) return;
+          const stats = state.playerStats[playerId] || {};
+          const total = stats.total ?? 0;
+          const ppg = stats.ppg ?? (stats.games ? stats.total / stats.games : 0);
+          if (total <= 0) return;
+          leaderboards[pos].push({
+            playerId,
+            name: formatPlayerName(playerInfo),
+            owner: teamName,
+            nflTeam: playerInfo.team || '--',
+            total,
+            ppg,
+          });
+        });
+
+        return {
+          teamName,
+          roster,
+          overallPositional,
+          startersBySlot,
+          startersValueByPos,
+          allPlayers,
+          totalValue,
+          startersValueTotal,
+          starterPpgTotal,
+          wins,
+          losses,
+          ties,
+          record,
+          totalFpts: pf,
+          pointsAgainst: pa,
+          teamPpg,
+          isUserTeam: roster.owner_id === state.userId,
+        };
+      });
+
+      Object.keys(leaderboards).forEach((pos) => {
+        leaderboards[pos] = leaderboards[pos]
+          .sort((a, b) => {
+            if (b.total !== a.total) return b.total - a.total;
+            if (b.ppg !== a.ppg) return b.ppg - a.ppg;
+            return a.name.localeCompare(b.name);
+          })
+          .slice(0, 10);
+      });
+
+      teams.sort((a, b) => b.totalValue - a.totalValue);
+      return { teams, leaderboards };
+    }
+
+    function normalizeSlot(slot) {
+      if (!slot) return null;
+      if (SLOT_ORDER.includes(slot)) return slot;
+      const normalized = SLOT_ALIASES[slot];
+      if (normalized) return normalized;
+      if (slot.includes('FLEX')) return 'FLEX';
+      if (slot.includes('QB')) return 'QB';
+      if (slot.includes('RB')) return 'RB';
+      if (slot.includes('WR')) return 'WR';
+      if (slot.includes('TE')) return 'TE';
+      return null;
+    }
+
+    function formatPlayerName(playerInfo) {
+      if (!playerInfo) return 'Unknown Player';
+      if (playerInfo.full_name) return playerInfo.full_name;
+      const first = playerInfo.first_name ? `${playerInfo.first_name} ` : '';
+      const last = playerInfo.last_name || '';
+      const name = `${first}${last}`.trim();
+      return name || 'Unknown Player';
+    }
+
+    function combineScore(base, decimal) {
+      const whole = toNumber(base);
+      const fraction = typeof decimal === 'string' || typeof decimal === 'number'
+        ? toNumber(decimal) / 100
+        : 0;
+      return whole + fraction;
+    }
+
+    function getKtcValue(id) {
+      if (!id) return 0;
+      const source = state.isSuperflex ? state.ktcSflx : state.ktcOneQb;
+      return source[id]?.ktc ?? 0;
+    }
+
+    function getOwnedPicks(rosterId, allRosters, tradedPicks, leagueInfo) {
+      const currentYear = new Date().getFullYear();
+      const picks = [];
+      const draftRounds = leagueInfo?.settings?.draft_rounds || 4;
+
+      (allRosters || []).forEach((roster) => {
+        for (let year = 1; year <= 4; year += 1) {
+          const season = String(currentYear + year);
+          for (let round = 1; round <= draftRounds; round += 1) {
+            picks.push({
+              season,
+              round,
+              roster_id: roster.roster_id,
+              owner_id: roster.roster_id,
+            });
+          }
+        }
+      });
+
+      (tradedPicks || []).forEach((trade) => {
+        const pickIndex = picks.findIndex(
+          (pick) => pick.season === trade.season && pick.round === trade.round && pick.roster_id === trade.roster_id,
+        );
+        if (pickIndex !== -1) {
+          picks[pickIndex].owner_id = trade.owner_id;
+        }
+      });
+
+      return picks
+        .filter((pick) => pick.owner_id === rosterId)
+        .sort((a, b) => a.season.localeCompare(b.season) || a.round - b.round)
+        .map((pick) => ({ ...pick, label: `${pick.season} Mid ${ordinal(pick.round)}` }));
+    }
+
+    function ordinal(i) {
+      const j = i % 10;
+      const k = i % 100;
+      if (j === 1 && k !== 11) return `${i}st`;
+      if (j === 2 && k !== 12) return `${i}nd`;
+      if (j === 3 && k !== 13) return `${i}rd`;
+      return `${i}th`;
+    }
+
+    function renderSummaryStats(teams) {
+      const userTeam = teams.find((team) => team.isUserTeam);
+      if (!userTeam) {
+        elements.summaryStats.classList.add('hidden');
+        return;
+      }
+
+      const totalTeams = teams.length;
+      const overallRank = computeRank(teams, (team) => team.isUserTeam);
+
+      const starterValueRank = computeRank(
+        [...teams].sort((a, b) => b.startersValueTotal - a.startersValueTotal),
+        (team) => team.isUserTeam,
+      );
+
+      const fptsRank = computeRank(
+        [...teams].sort((a, b) => b.totalFpts - a.totalFpts),
+        (team) => team.isUserTeam,
+      );
+
+      const starterPpgRank = computeRank(
+        [...teams].sort((a, b) => b.starterPpgTotal - a.starterPpgTotal),
+        (team) => team.isUserTeam,
+      );
+
+      const positionalRanks = {};
+      POSITION_ORDER.forEach((pos) => {
+        positionalRanks[pos] = computeRank(
+          [...teams].sort((a, b) => (b.startersValueByPos[pos] || 0) - (a.startersValueByPos[pos] || 0)),
+          (team) => team.isUserTeam,
+        );
+      });
+
+      const chips = [
+        {
+          label: 'Overall Rank',
+          value: formatRankValue(overallRank),
+          meta: totalTeams ? `of ${totalTeams}` : '',
+          accent: overallRank ? getRankColor(overallRank, totalTeams) : undefined,
+        },
+        {
+          label: 'Total Roster Value',
+          value: formatNumber(userTeam.totalValue),
+          meta: 'KTC',
+        },
+        {
+          label: 'Starter Value',
+          value: formatNumber(userTeam.startersValueTotal),
+          meta: starterValueRank ? `Rank ${starterValueRank}/${totalTeams}` : 'Rank NA',
+          accent: starterValueRank ? getRankColor(starterValueRank, totalTeams) : undefined,
+        },
+        {
+          label: 'Total FPTS',
+          value: userTeam.totalFpts.toFixed(1),
+          meta: fptsRank ? `Rank ${fptsRank}/${totalTeams}` : 'Rank NA',
+          accent: fptsRank ? getRankColor(fptsRank, totalTeams) : undefined,
+        },
+        {
+          label: 'Starter PPG',
+          value: userTeam.starterPpgTotal.toFixed(1),
+          meta: starterPpgRank ? `Rank ${starterPpgRank}/${totalTeams}` : 'Rank NA',
+          accent: starterPpgRank ? getRankColor(starterPpgRank, totalTeams) : undefined,
+        },
+        {
+          label: 'QB Starter Rank',
+          value: formatRankValue(positionalRanks.QB),
+          meta: totalTeams ? `of ${totalTeams}` : '',
+          accent: positionalRanks.QB ? getRankColor(positionalRanks.QB, totalTeams) : undefined,
+        },
+        {
+          label: 'RB Starter Rank',
+          value: formatRankValue(positionalRanks.RB),
+          meta: totalTeams ? `of ${totalTeams}` : '',
+          accent: positionalRanks.RB ? getRankColor(positionalRanks.RB, totalTeams) : undefined,
+        },
+        {
+          label: 'WR Starter Rank',
+          value: formatRankValue(positionalRanks.WR),
+          meta: totalTeams ? `of ${totalTeams}` : '',
+          accent: positionalRanks.WR ? getRankColor(positionalRanks.WR, totalTeams) : undefined,
+        },
+        {
+          label: 'TE Starter Rank',
+          value: formatRankValue(positionalRanks.TE),
+          meta: totalTeams ? `of ${totalTeams}` : '',
+          accent: positionalRanks.TE ? getRankColor(positionalRanks.TE, totalTeams) : undefined,
+        },
+      ];
+
+      elements.summaryStats.innerHTML = chips
+        .map((chip) => `
+          <article class="analyzer-chip">
+            <span class="chip-label">${chip.label}</span>
+            <span class="chip-value"${chip.accent ? ` style="color: ${chip.accent};"` : ''}>${chip.value}</span>
+            <span class="chip-meta">${chip.meta}</span>
+          </article>
+        `)
+        .join('');
+
+      elements.summaryStats.classList.remove('hidden');
+    }
+
+    function renderLineupChart(teams) {
+      state.lineupData = buildLineupDatasets(teams);
+      if (state.charts.lineup) {
+        state.charts.lineup.destroy();
+      }
+      const metricConfig = state.lineupData[state.currentLineupMetric];
+      state.charts.lineup = createStackedBarChart(
+        elements.startersCanvas,
+        teams.map((team) => team.teamName),
+        metricConfig.datasets,
+        buildLineupOptions(metricConfig.max, state.currentLineupMetric, teams),
+      );
+    }
+
+    function updateLineupChart() {
+      if (!state.charts.lineup || !state.lineupData) return;
+      const metricConfig = state.lineupData[state.currentLineupMetric];
+      state.charts.lineup.data.datasets = metricConfig.datasets;
+      state.charts.lineup.options = buildLineupOptions(metricConfig.max, state.currentLineupMetric, state.teams);
+      state.charts.lineup.update();
+    }
+
+    function buildLineupDatasets(teams) {
+      const labels = teams.map((team) => team.teamName);
+
+      const createDatasetForMetric = (metric) => {
+        const datasets = [];
+        SLOT_ORDER.forEach((slot) => {
+          const values = teams.map((team) => team.startersBySlot[slot]?.[metric] ?? 0);
+          if (!values.some((value) => value > 0)) return;
+          datasets.push({
+            label: SLOT_LABELS[slot] || slot,
+            slotKey: slot,
+            data: values,
+            backgroundColor: (context) => createGradient(context, LINEUP_COLORS[slot] || LINEUP_COLORS.FLEX),
+            borderColor: 'rgba(255,255,255,0.12)',
+            borderWidth: 1,
+            borderRadius: 10,
+            barPercentage: 0.9,
+            categoryPercentage: 0.7,
+            stack: 'lineup',
+          });
+        });
+
+        const maxValue = Math.max(
+          0,
+          ...teams.map((team) => (metric === 'value' ? team.startersValueTotal : team.starterPpgTotal)),
+        );
+
+        return { labels, datasets, max: maxValue };
+      };
+
+      return {
+        value: createDatasetForMetric('value'),
+        ppg: createDatasetForMetric('ppg'),
+      };
+    }
+
+    function buildLineupOptions(max, metric, teams) {
+      const formatter = metric === 'value' ? formatNumber : formatPpg;
+      const axisMax = metric === 'value'
+        ? roundUpTo(max, 5000)
+        : roundUpTo(max, 5);
+
+      return {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: 'y',
+        interaction: { mode: 'nearest', intersect: false },
+        scales: {
+          x: {
+            stacked: true,
+            grid: { color: 'rgba(234, 235, 240, 0.08)' },
+            ticks: {
+              color: '#EAEBF0',
+              callback: (value) => formatter(value),
+            },
+            max: axisMax,
+          },
+          y: {
+            stacked: true,
+            grid: { display: false },
+            ticks: {
+              color: '#EAEBF0',
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: {
+              color: '#EAEBF0',
+              usePointStyle: true,
+            },
+          },
+          tooltip: {
+            backgroundColor: 'rgba(13, 14, 35, 0.92)',
+            borderColor: 'rgba(118, 109, 255, 0.5)',
+            borderWidth: 1,
+            callbacks: {
+              label: (context) => {
+                const value = context.raw ?? 0;
+                return `${context.dataset.label}: ${formatter(value)}`;
+              },
+              footer: (tooltipItems) => {
+                if (!tooltipItems.length) return '';
+                const teamIndex = tooltipItems[0].dataIndex;
+                const slotKey = tooltipItems[0].dataset.slotKey;
+                const team = teams[teamIndex];
+                const players = team?.startersBySlot?.[slotKey]?.players || [];
+                const valueKey = metric === 'value' ? 'value' : 'ppg';
+                return players
+                  .slice()
+                  .sort((a, b) => (b[valueKey] || 0) - (a[valueKey] || 0))
+                  .slice(0, 3)
+                  .map((player) => `${player.name}: ${formatter(player[valueKey] || 0)}`)
+                  .join('\n');
+              },
+            },
+          },
+        },
+      };
+    }
+
+    function createGradient(context, colors = ['rgba(118, 109, 255, 0.8)', 'rgba(118, 109, 255, 0.4)']) {
+      const { chart } = context;
+      const { ctx, chartArea } = chart;
+      if (!chartArea) return colors[0];
+      const gradient = ctx.createLinearGradient(chartArea.left, 0, chartArea.right, 0);
+      gradient.addColorStop(0, colors[0]);
+      gradient.addColorStop(1, colors[1] ?? colors[0]);
+      return gradient;
+    }
+
+    function createStackedBarChart(canvas, labels, datasets, options) {
+      return new Chart(canvas, {
+        type: 'bar',
+        data: { labels, datasets },
+        options,
+      });
+    }
+
+    function renderOverallChart(teams) {
+      if (state.charts.overall) {
+        state.charts.overall.destroy();
+      }
+
+      const labels = teams.map((team) => team.teamName);
+      const positions = ['QB', 'RB', 'WR', 'TE', 'Picks'];
+      const datasets = positions
+        .map((pos) => {
+          const values = teams.map((team) => team.overallPositional[pos] || 0);
+          if (!values.some((value) => value > 0)) return null;
+          return {
+            label: SLOT_LABELS[pos] || pos,
+            slotKey: pos,
+            data: values,
+            backgroundColor: (context) => createGradient(context, LINEUP_COLORS[pos] || LINEUP_COLORS.FLEX),
+            borderColor: 'rgba(255,255,255,0.1)',
+            borderWidth: 1,
+            borderRadius: 10,
+            barPercentage: 0.9,
+            categoryPercentage: 0.7,
+            stack: 'overall',
+          };
+        })
+        .filter(Boolean);
+
+      const maxValue = Math.max(0, ...teams.map((team) => team.totalValue));
+
+      state.charts.overall = createStackedBarChart(
+        elements.overallCanvas,
+        labels,
+        datasets,
+        {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          interaction: { mode: 'nearest', intersect: false },
+          scales: {
+            x: {
+              stacked: true,
+              grid: { color: 'rgba(234, 235, 240, 0.08)' },
+              ticks: {
+                color: '#EAEBF0',
+                callback: (value) => formatNumber(value),
+              },
+              max: roundUpTo(maxValue, 10000),
+            },
+            y: {
+              stacked: true,
+              grid: { display: false },
+              ticks: { color: '#EAEBF0' },
+            },
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: { color: '#EAEBF0', usePointStyle: true },
+            },
+            tooltip: {
+              backgroundColor: 'rgba(13, 14, 35, 0.92)',
+              borderColor: 'rgba(118, 109, 255, 0.5)',
+              borderWidth: 1,
+              callbacks: {
+                label: (context) => {
+                  const value = context.raw ?? 0;
+                  return `${context.dataset.label}: ${formatNumber(value)}`;
+                },
+                footer: (tooltipItems) => {
+                  if (!tooltipItems.length) return '';
+                  const teamIndex = tooltipItems[0].dataIndex;
+                  const slotKey = tooltipItems[0].dataset.slotKey;
+                  const players = state.teams[teamIndex]?.allPlayers || [];
+                  const list = players.filter((player) => player.pos === slotKey).slice(0, 3);
+                  return list
+                    .map((player) => `${player.name}: ${formatNumber(player.ktc)}`)
+                    .join('\n');
+                },
+              },
+            },
+          },
+        },
+      );
+    }
+
+    function renderRadarChart(teams) {
+      const userTeam = teams.find((team) => team.isUserTeam);
+      if (!userTeam) return;
+
+      const positions = POSITION_ORDER;
+      const leagueAverages = {};
+      const userValues = {};
+
+      positions.forEach((pos) => {
+        let totalLeagueValue = 0;
+        teams.forEach((team) => {
+          const topTwo = team.allPlayers.filter((player) => player.pos === pos).slice(0, 2);
+          totalLeagueValue += topTwo.reduce((sum, player) => sum + player.ktc, 0);
+        });
+        leagueAverages[pos] = teams.length > 0 ? totalLeagueValue / teams.length : 0;
+
+        const userTopTwo = userTeam.allPlayers.filter((player) => player.pos === pos).slice(0, 2);
+        userValues[pos] = userTopTwo.reduce((sum, player) => sum + player.ktc, 0);
+      });
+
+      if (state.charts.radar) {
+        state.charts.radar.destroy();
+      }
+
+      state.charts.radar = new Chart(elements.radarCanvas, {
+        type: 'radar',
+        data: {
+          labels: positions.map((pos) => SLOT_LABELS[pos] || pos),
+          datasets: [
+            {
+              label: 'Your Team (Top 2)',
+              data: positions.map((pos) => userValues[pos] || 0),
+              fill: true,
+              backgroundColor: 'rgba(118, 109, 255, 0.35)',
+              borderColor: 'rgba(118, 109, 255, 0.95)',
+              pointBackgroundColor: 'rgba(118, 109, 255, 1)',
+              pointBorderColor: '#fff',
+              pointRadius: 4,
+            },
+            {
+              label: 'League Average (Top 2)',
+              data: positions.map((pos) => leagueAverages[pos] || 0),
+              fill: true,
+              backgroundColor: 'rgba(66, 194, 255, 0.25)',
+              borderColor: 'rgba(66, 194, 255, 0.9)',
+              pointBackgroundColor: 'rgba(66, 194, 255, 1)',
+              pointBorderColor: '#fff',
+              pointRadius: 4,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            r: {
+              angleLines: { color: 'rgba(234, 235, 240, 0.1)' },
+              grid: { color: 'rgba(234, 235, 240, 0.1)' },
+              pointLabels: {
+                color: '#EAEBF0',
+                font: { size: 13, weight: '500', family: "'Product Sans', 'Google Sans', sans-serif" },
+              },
+              ticks: {
+                color: '#EAEBF0',
+                backdropColor: 'rgba(13, 14, 27, 0.65)',
+                display: true,
+                showLabelBackdrop: true,
+                callback: (value) => formatNumber(value),
+              },
+            },
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: { color: '#EAEBF0' },
+            },
+          },
+        },
+      });
+    }
+
+    function renderStandings(teams) {
+      const standings = teams
+        .map((team) => ({
+          teamName: team.teamName,
+          wins: team.wins,
+          losses: team.losses,
+          ties: team.ties,
+          record: team.record,
+          pf: team.totalFpts,
+          pa: team.pointsAgainst,
+          winPct: computeWinPct(team.wins, team.losses, team.ties),
+        }))
+        .sort((a, b) => {
+          if (b.winPct !== a.winPct) return b.winPct - a.winPct;
+          if (b.wins !== a.wins) return b.wins - a.wins;
+          if (b.pf !== a.pf) return b.pf - a.pf;
+          return a.teamName.localeCompare(b.teamName);
+        });
+
+      elements.standingsBody.innerHTML = standings
+        .map((team) => `
+          <tr>
+            <td data-label="Team">${team.teamName}</td>
+            <td data-label="Record">${team.record}</td>
+            <td data-label="PF">${team.pf.toFixed(1)}</td>
+            <td data-label="PA">${team.pa.toFixed(1)}</td>
+          </tr>
+        `)
+        .join('');
+    }
+
+    function computeWinPct(wins, losses, ties) {
+      const games = wins + losses + ties;
+      if (games === 0) return 0;
+      return (wins + ties * 0.5) / games;
+    }
+
+    function renderLeagueLeaders() {
+      const position = state.activeLeaderboard;
+      const leaders = state.leaderboards[position] || [];
+      if (!leaders.length) {
+        elements.leaderboardBody.innerHTML = '<tr><td colspan="6" class="empty-row">No scoring data available.</td></tr>';
+        return;
+      }
+
+      elements.leaderboardBody.innerHTML = leaders
+        .map((entry, index) => `
+          <tr>
+            <td>${index + 1}</td>
+            <td>${entry.name}</td>
+            <td>${entry.nflTeam}</td>
+            <td>${entry.owner}</td>
+            <td>${entry.total.toFixed(1)}</td>
+            <td>${entry.ppg.toFixed(1)}</td>
+          </tr>
+        `)
+        .join('');
+    }
+
+    function populateLeagueSelect(leagues) {
+      const select = elements.leagueSelect;
+      if (!select) return;
+      select.innerHTML = '<option value="">Select a league...</option>';
+      leagues.forEach((league) => {
+        const option = document.createElement('option');
+        option.value = league.league_id;
+        option.textContent = league.name;
+        select.appendChild(option);
+      });
+      select.disabled = false;
+    }
+
+    function setLoading(isLoading) {
+      if (!elements.loading) return;
+      if (isLoading) {
+        elements.loading.classList.remove('hidden');
+      } else {
+        elements.loading.classList.add('hidden');
+      }
+    }
+
+    function roundUpTo(value, step) {
+      if (value <= 0) return step;
+      return Math.ceil(value / step) * step;
+    }
+
+    function computeRank(list, predicate) {
+      const index = list.findIndex(predicate);
+      return index === -1 ? null : index + 1;
+    }
+
+    function formatRankValue(rank) {
+      if (!rank) return 'NA';
+      return `${rank}`;
+    }
+
+    function formatNumber(value) {
+      if (!Number.isFinite(value)) return '0';
+      if (Math.abs(value) >= 1000) {
+        return Math.round(value).toLocaleString();
+      }
+      return value.toFixed(0);
+    }
+
+    function formatPpg(value) {
+      if (!Number.isFinite(value)) return '0.0';
+      return value.toFixed(1);
+    }
+
+    function getRankColor(rank, total) {
+      const percentile = (total - rank + 1) / total;
+      if (percentile >= 0.8) return '#00EBC7';
+      if (percentile >= 0.6) return '#58A7FF';
+      if (percentile >= 0.4) return '#EAEBF0';
+      if (percentile >= 0.2) return '#FF7F50';
+      return '#FF3A75';
+    }
+  });
+})();

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -5865,3 +5865,382 @@ body[data-page="research"] .app-header {
   background: rgb(67 71 87 / 63%);
 }
 
+
+/* === League Analyzer Refresh === */
+body[data-page="analyzer"] .analyzer-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-bottom: 3rem;
+}
+
+body[data-page="analyzer"] .analyzer-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: var(--panel-border-radius);
+  background: rgba(13, 15, 35, 0.35);
+  border: 1px solid rgba(128, 138, 189, 0.25);
+}
+
+body[data-page="analyzer"] .analyzer-hero-intro {
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+body[data-page="analyzer"] .analyzer-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-secondary);
+  background: rgba(118, 109, 255, 0.12);
+  border: 1px solid rgba(118, 109, 255, 0.4);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+}
+
+body[data-page="analyzer"] .analyzer-hero h1 {
+  font-size: clamp(1.65rem, 2.8vw, 2.4rem);
+  line-height: 1.2;
+  margin: 0;
+}
+
+body[data-page="analyzer"] .analyzer-hero p {
+  color: var(--color-text-secondary);
+  max-width: 620px;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+body[data-page="analyzer"] .analyzer-hero-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+body[data-page="analyzer"] .analyzer-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  background: rgba(15, 17, 38, 0.55);
+  border: 1px solid rgba(118, 109, 255, 0.18);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+}
+
+body[data-page="analyzer"] .analyzer-control-group .control-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-secondary);
+}
+
+body[data-page="analyzer"] .analyzer-control-group .control-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+body[data-page="analyzer"] .analyzer-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.25rem 1.5rem;
+  font-size: 1.05rem;
+  color: var(--color-text-secondary);
+}
+
+body[data-page="analyzer"] .loading-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+body[data-page="analyzer"] .loading-indicator::before {
+  content: '';
+  height: 0.9rem;
+  width: 0.9rem;
+  border-radius: 999px;
+  border: 2px solid rgba(118, 109, 255, 0.35);
+  border-top-color: rgba(118, 109, 255, 0.9);
+  animation: analyzer-spin 1.1s linear infinite;
+}
+
+@keyframes analyzer-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+body[data-page="analyzer"] .analyzer-summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+}
+
+body[data-page="analyzer"] .analyzer-chip {
+  position: relative;
+  padding: 1.1rem 1.2rem;
+  border-radius: 14px;
+  border: 1px solid rgba(128, 138, 189, 0.22);
+  background: linear-gradient(135deg, rgba(22, 25, 48, 0.65), rgba(11, 12, 26, 0.65));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 14px 32px rgba(5, 7, 15, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-height: 120px;
+}
+
+body[data-page="analyzer"] .analyzer-chip::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), transparent 55%);
+}
+
+body[data-page="analyzer"] .analyzer-chip .chip-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-secondary);
+}
+
+body[data-page="analyzer"] .analyzer-chip .chip-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+body[data-page="analyzer"] .analyzer-chip .chip-meta {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+body[data-page="analyzer"] .analyzer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+body[data-page="analyzer"] .analyzer-panels-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 1024px) {
+  body[data-page="analyzer"] .analyzer-panels-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+body[data-page="analyzer"] .analyzer-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: var(--panel-border-radius);
+  background: rgba(13, 15, 35, 0.42);
+  border: 1px solid rgba(128, 138, 189, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 18px 42px rgba(4, 6, 15, 0.45);
+}
+
+body[data-page="analyzer"] .analyzer-panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+body[data-page="analyzer"] .analyzer-panel-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+body[data-page="analyzer"] .analyzer-panel-header p {
+  margin: 0.2rem 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+body[data-page="analyzer"] .analyzer-panel-body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body[data-page="analyzer"] .analyzer-chart {
+  position: relative;
+  width: 100%;
+  height: 400px;
+}
+
+body[data-page="analyzer"] .analyzer-chart--radar {
+  min-height: 360px;
+}
+
+body[data-page="analyzer"] .analyzer-panel-body--stacked {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  body[data-page="analyzer"] .analyzer-panel-body--stacked {
+    flex-direction: row;
+    align-items: stretch;
+  }
+  body[data-page="analyzer"] .analyzer-panel-body--stacked > * {
+    flex: 1 1 0%;
+  }
+  body[data-page="analyzer"] .analyzer-chart--radar {
+    height: auto;
+  }
+}
+
+body[data-page="analyzer"] .analyzer-toggle {
+  display: inline-flex;
+  background: rgba(19, 21, 38, 0.75);
+  border: 1px solid rgba(118, 109, 255, 0.25);
+  border-radius: 999px;
+  padding: 0.25rem;
+  gap: 0.35rem;
+}
+
+body[data-page="analyzer"] .analyzer-toggle .toggle-option {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  transition: all 0.2s ease;
+}
+
+body[data-page="analyzer"] .analyzer-toggle .toggle-option.active {
+  background: linear-gradient(135deg, rgba(118, 109, 255, 0.8), rgba(118, 109, 255, 0.45));
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(118, 109, 255, 0.35);
+}
+
+body[data-page="analyzer"] .analyzer-toggle .toggle-option:focus-visible {
+  outline: 2px solid rgba(118, 109, 255, 0.65);
+}
+
+body[data-page="analyzer"] .analyzer-standings {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(15, 17, 38, 0.55);
+  border: 1px solid rgba(118, 109, 255, 0.18);
+  border-radius: 16px;
+  padding: 1.1rem 1.25rem;
+}
+
+body[data-page="analyzer"] .analyzer-standings-header h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+body[data-page="analyzer"] .analyzer-standings-header p {
+  margin: 0.3rem 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+}
+
+body[data-page="analyzer"] .analyzer-standings-table-wrapper {
+  overflow-x: auto;
+}
+
+body[data-page="analyzer"] .analyzer-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+body[data-page="analyzer"] .analyzer-table thead tr {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-secondary);
+  font-size: 0.7rem;
+}
+
+body[data-page="analyzer"] .analyzer-table th,
+body[data-page="analyzer"] .analyzer-table td {
+  padding: 0.55rem 0.65rem;
+  border-bottom: 1px solid rgba(128, 138, 189, 0.18);
+  text-align: left;
+  white-space: nowrap;
+}
+
+body[data-page="analyzer"] .analyzer-table tbody tr:last-child th,
+body[data-page="analyzer"] .analyzer-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+body[data-page="analyzer"] .analyzer-filter-group {
+  display: inline-flex;
+  gap: 0.5rem;
+  background: rgba(18, 20, 40, 0.75);
+  border: 1px solid rgba(118, 109, 255, 0.25);
+  border-radius: 999px;
+  padding: 0.25rem 0.35rem;
+}
+
+body[data-page="analyzer"] .analyzer-filter-group .filter-chip {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition: all 0.2s ease;
+}
+
+body[data-page="analyzer"] .analyzer-filter-group .filter-chip.active {
+  background: linear-gradient(135deg, rgba(118, 109, 255, 0.85), rgba(118, 109, 255, 0.45));
+  color: #fff;
+  box-shadow: 0 6px 16px rgba(118, 109, 255, 0.3);
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard {
+  overflow-x: auto;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard .empty-row {
+  text-align: center;
+  padding: 1.5rem 0;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 640px) {
+  body[data-page="analyzer"] .analyzer-chip {
+    min-height: 110px;
+  }
+  body[data-page="analyzer"] .analyzer-table th,
+  body[data-page="analyzer"] .analyzer-table td {
+    padding: 0.5rem;
+  }
+  body[data-page="analyzer"] .analyzer-panel {
+    padding: 1.25rem;
+  }
+  body[data-page="analyzer"] .analyzer-chart {
+    height: 320px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Rebuild the analyzer layout to match the research theme with new hero controls, standings, and leaderboard sections.
- Move analyzer logic into a dedicated script that pulls Sleeper scoring data for totals, PPG toggles, standings, and leaderboards.
- Refresh analyzer-specific styling for chips, panels, charts, toggles, and tables to deliver the updated aesthetic.

## Testing
- No automated tests were run (not provided).


------
https://chatgpt.com/codex/tasks/task_e_68d4254d9fb4832ea8cdad169ad67082