### PR TITLE
Adjust league analyzer styling and labels

### DIFF
--- a/DHP2_DeployDraft1.2/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.2/scripts/analyzer.js
@@ -1007,6 +1007,22 @@
       return `${i}th`;
     }
 
+    function abbreviateName(name) {
+      if (!name) return '';
+      const trimmed = String(name).trim();
+      if (!trimmed) return '';
+      const parts = trimmed.split(/\s+/);
+      if (parts.length === 1) {
+        return parts[0];
+      }
+
+      const first = parts[0];
+      const initialMatch = first.match(/[A-Za-z]/);
+      const initial = initialMatch ? `${first[initialMatch.index].toUpperCase()}.` : '';
+      const remainder = parts.slice(1).join(' ');
+      return initial && remainder ? `${initial} ${remainder}` : trimmed;
+    }
+
     function renderSummaryStats(teams) {
       const userTeam = teams.find((team) => team.isUserTeam);
       if (!userTeam) {
@@ -1056,7 +1072,7 @@
           accent: overallRank ? getRankColor(overallRank, totalTeams) : undefined,
         },
         {
-          label: 'Total Roster Value',
+          label: 'TTL Team Value',
           value: formatNumber(userTeam.totalValue),
           meta: 'KTC',
         },
@@ -1079,8 +1095,8 @@
           accent: starterPpgRank ? getRankColor(starterPpgRank, totalTeams) : undefined,
         },
         {
-          label: 'Top Scoring Player',
-          value: topScorer?.name || '—',
+          label: 'Top Scorer',
+          value: abbreviateName(topScorer?.name) || '—',
           meta: topScorerMeta,
           accent: topScorer?.total ? 'var(--color-accent-secondary)' : undefined,
           className: 'analyzer-chip--top-scorer',
@@ -1144,7 +1160,7 @@
             slotKey: slot,
             data: values,
             backgroundColor: (context) => createGradient(context, gradientPair),
-            borderColor: hexToRgba(hex, 0.95),
+            borderColor: hexToRgba(hex, 0.85),
             borderWidth: 1,
             borderRadius: 10,
             barPercentage: 0.9,
@@ -1169,9 +1185,10 @@
 
     function buildLineupOptions(max, metric, teams) {
       const formatter = metric === 'value' ? formatNumber : formatPpg;
+      const paddedMax = max > 0 ? max * 1.08 : max;
       const axisMax = metric === 'value'
-        ? roundUpTo(max, 5000)
-        : roundUpTo(max, 5);
+        ? roundUpTo(paddedMax, 5000)
+        : roundUpTo(paddedMax, 5);
       const isMobile = window.matchMedia('(max-width: 640px)').matches;
 
       return {
@@ -1181,7 +1198,7 @@
         interaction: { mode: 'nearest', intersect: false },
         layout: {
           padding: {
-            left: isMobile ? 8 : 16,
+            left: isMobile ? 2 : 4,
             right: isMobile ? 14 : 18,
             top: 8,
             bottom: 8,
@@ -1206,7 +1223,7 @@
             grid: { display: false },
             ticks: {
               color: '#EAEBF0',
-              padding: isMobile ? 4 : 8,
+              padding: isMobile ? 2 : 4,
               font: {
                 size: isMobile ? 10 : 12,
                 family: "'Product Sans', 'Google Sans', sans-serif",
@@ -1294,7 +1311,7 @@
     }
 
     function buildGradientPair(hex) {
-      return [hexToRgba(hex, 0.92), hexToRgba(hex, 0.45)];
+      return [hexToRgba(hex, 0.78), hexToRgba(hex, 0.32)];
     }
 
     function createStackedBarChart(canvas, labels, datasets, options) {
@@ -1323,7 +1340,7 @@
             slotKey: pos,
             data: values,
             backgroundColor: (context) => createGradient(context, gradientPair),
-            borderColor: hexToRgba(hex, 0.92),
+            borderColor: hexToRgba(hex, 0.85),
             borderWidth: 1,
             borderRadius: 10,
             barPercentage: 0.9,
@@ -1334,6 +1351,7 @@
         .filter(Boolean);
 
       const maxValue = Math.max(0, ...teams.map((team) => team.totalValue));
+      const paddedMaxValue = maxValue > 0 ? maxValue * 1.08 : maxValue;
       const isMobile = window.matchMedia('(max-width: 640px)').matches;
 
       state.charts.overall = createStackedBarChart(
@@ -1347,7 +1365,7 @@
           interaction: { mode: 'nearest', intersect: false },
           layout: {
             padding: {
-              left: isMobile ? 8 : 16,
+              left: isMobile ? 2 : 4,
               right: isMobile ? 14 : 18,
               top: 8,
               bottom: 8,
@@ -1365,14 +1383,14 @@
                   family: "'Product Sans', 'Google Sans', sans-serif",
                 },
               },
-              max: roundUpTo(maxValue, 10000),
+              max: roundUpTo(paddedMaxValue, 10000),
             },
             y: {
               stacked: true,
               grid: { display: false },
               ticks: {
                 color: '#EAEBF0',
-                padding: isMobile ? 4 : 8,
+                padding: isMobile ? 2 : 4,
                 font: {
                   size: isMobile ? 10 : 12,
                   family: "'Product Sans', 'Google Sans', sans-serif",
@@ -1492,6 +1510,9 @@
         options: {
           responsive: true,
           maintainAspectRatio: false,
+          layout: {
+            padding: 0,
+          },
           events: [],
           elements: {
             line: { tension: 0.32 },
@@ -1508,7 +1529,7 @@
               pointLabels: {
                 color: '#EAEBF0',
                 font: { size: 13, weight: '600', family: "'Product Sans', 'Google Sans', sans-serif" },
-                padding: 14,
+                padding: 8,
               },
             },
           },
@@ -1526,7 +1547,7 @@
             },
             analyzerRadarLabels: {
               font: '11px "Product Sans", "Google Sans", sans-serif',
-              offset: 20,
+              offset: 16,
             },
           },
         },
@@ -1579,16 +1600,19 @@
       }
 
       elements.leaderboardBody.innerHTML = leaders
-        .map((entry, index) => `
+        .map((entry, index) => {
+          const displayName = abbreviateName(entry.name) || '—';
+          return `
           <tr>
             <td>${index + 1}</td>
-            <td>${entry.name}</td>
+            <td>${displayName}</td>
             <td>${entry.nflTeam}</td>
             <td>${entry.owner}</td>
             <td>${entry.total.toFixed(1)}</td>
             <td>${entry.ppg.toFixed(1)}</td>
           </tr>
-        `)
+        `;
+        })
         .join('');
     }
 

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -228,8 +228,8 @@
             flex-direction: column;
             gap: 0.25rem;
             --header-icon-size: 2.25rem;
-            --header-control-height: 2.2rem;
-            --header-field-max-width: 160px;
+            --header-control-height: 1.85rem;
+            --header-field-max-width: 120px;
             --header-switcher-width: 12.25rem;
         }
 
@@ -441,7 +441,7 @@
                 /* · · Row 1 · · */
                 .username-area {
                     flex-grow: 1;
-                    min-width: 100px; /* prevent it from getting too small */
+                    min-width: 90px; /* prevent it from getting too small */
                     max-width: var(--header-field-max-width);
                     padding: 0;
                     height: var(--header-control-height);
@@ -458,8 +458,8 @@
           backdrop-filter: blur(4px) saturate(110%);
           box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
           color: #c4c8eaba;
-          padding: 0.23rem 0.5rem;
-          font-size: 0.7rem;
+          padding: 0.18rem 0.45rem;
+          font-size: 0.65rem;
           font-weight: 300;
           width: 100%;
           height: 100%;
@@ -510,8 +510,8 @@
             -webkit-backdrop-filter: blur(4px) saturate(110%);
             backdrop-filter: blur(4px) saturate(110%);
             box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
-            padding: 0.32rem 1.25rem 0.32rem 0.5rem;
-            font-size: 0.75rem;
+            padding: 0.26rem 1.1rem 0.26rem 0.45rem;
+            font-size: 0.7rem;
             color: #c4c8eaba;
             font-weight: 300;
             width: 100%;
@@ -6026,8 +6026,9 @@ body[data-page="analyzer"] .analyzer-chip .chip-meta {
 }
 
 body[data-page="analyzer"] .analyzer-chip--top-scorer .chip-value {
-  font-size: 1.05rem;
-  line-height: 1.25;
+  font-size: 0.95rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 body[data-page="analyzer"] .analyzer-chip--top-scorer .chip-meta {
@@ -6102,6 +6103,14 @@ body[data-page="analyzer"] .analyzer-chart {
 
 body[data-page="analyzer"] .analyzer-chart--radar {
   min-height: 360px;
+}
+
+body[data-page="analyzer"] .analyzer-radar-section {
+  gap: 0.9rem;
+}
+
+body[data-page="analyzer"] .analyzer-radar-section .analyzer-panel-body {
+  gap: 0.75rem;
 }
 
 body[data-page="analyzer"] .analyzer-panel-body--stacked {
@@ -6242,6 +6251,19 @@ body[data-page="analyzer"] .analyzer-leaderboard .empty-row {
   text-align: center;
   padding: 1.5rem 0;
   color: var(--color-text-secondary);
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard .analyzer-table th:first-child,
+body[data-page="analyzer"] .analyzer-leaderboard .analyzer-table td:first-child {
+  text-align: center;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard .analyzer-table td:nth-child(2) {
+  white-space: nowrap;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard .analyzer-table td:nth-child(4) {
+  font-size: 0.8rem;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- abbreviate leaderboard and summary chip player names, rename chips, and reuse a helper for consistent formatting
- tweak stacked bar chart sizing to add breathing room for labels, reduce left padding, and soften bar fills
- tighten radar panel spacing, shrink header inputs, and adjust league leader table alignment and typography

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d45e34d160832ea6f475bbdc1abd71