### PR TITLE
Refine League Analyzer layout and labels

### DIFF
--- a/DHP2_DeployDraft1.2/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.2/scripts/analyzer.js
@@ -231,9 +231,11 @@
           let y = isHorizontal ? center : primaryPixel - offset;
 
           if (isHorizontal) {
-            if (x > chartArea.right - 4) {
-              ctx.textAlign = 'right';
-              x = chartArea.right - 4;
+            const layoutPadding = chart.options?.layout?.padding || 0;
+            const paddingRight = typeof layoutPadding === 'number' ? layoutPadding : layoutPadding.right || 0;
+            const maxX = chart.width - paddingRight - 4;
+            if (x > maxX) {
+              x = maxX;
             }
             y = center;
           } else {
@@ -1007,6 +1009,20 @@
       return `${i}th`;
     }
 
+    function abbreviateFirstName(fullName) {
+      if (typeof fullName !== 'string') return fullName || '';
+      const trimmed = fullName.trim();
+      if (!trimmed) return '';
+      const parts = trimmed.split(/\s+/);
+      if (parts.length === 1) {
+        return parts[0];
+      }
+      const [first, ...rest] = parts;
+      const initial = first ? `${first.charAt(0).toUpperCase()}.` : '';
+      const remainder = rest.join(' ');
+      return remainder ? `${initial} ${remainder}`.trim() : initial;
+    }
+
     function renderSummaryStats(teams) {
       const userTeam = teams.find((team) => team.isUserTeam);
       if (!userTeam) {
@@ -1056,7 +1072,7 @@
           accent: overallRank ? getRankColor(overallRank, totalTeams) : undefined,
         },
         {
-          label: 'Total Roster Value',
+          label: 'TTL Team Value',
           value: formatNumber(userTeam.totalValue),
           meta: 'KTC',
         },
@@ -1079,8 +1095,8 @@
           accent: starterPpgRank ? getRankColor(starterPpgRank, totalTeams) : undefined,
         },
         {
-          label: 'Top Scoring Player',
-          value: topScorer?.name || '—',
+          label: 'Top Scorer',
+          value: topScorer?.name ? abbreviateFirstName(topScorer.name) : '—',
           meta: topScorerMeta,
           accent: topScorer?.total ? 'var(--color-accent-secondary)' : undefined,
           className: 'analyzer-chip--top-scorer',
@@ -1181,10 +1197,10 @@
         interaction: { mode: 'nearest', intersect: false },
         layout: {
           padding: {
-            left: isMobile ? 8 : 16,
-            right: isMobile ? 14 : 18,
-            top: 8,
-            bottom: 8,
+            left: isMobile ? 2 : 4,
+            right: isMobile ? 34 : 46,
+            top: 6,
+            bottom: 6,
           },
         },
         scales: {
@@ -1206,7 +1222,7 @@
             grid: { display: false },
             ticks: {
               color: '#EAEBF0',
-              padding: isMobile ? 4 : 8,
+              padding: isMobile ? 1 : 2,
               font: {
                 size: isMobile ? 10 : 12,
                 family: "'Product Sans', 'Google Sans', sans-serif",
@@ -1259,7 +1275,7 @@
           },
           analyzerBarTotals: {
             enabled: true,
-            offset: 12,
+            offset: isMobile ? 10 : 18,
             formatter: (value) => formatter(value),
             mobileFont: '9px "Product Sans", "Google Sans", sans-serif',
           },
@@ -1294,7 +1310,7 @@
     }
 
     function buildGradientPair(hex) {
-      return [hexToRgba(hex, 0.92), hexToRgba(hex, 0.45)];
+      return [hexToRgba(hex, 0.8), hexToRgba(hex, 0.32)];
     }
 
     function createStackedBarChart(canvas, labels, datasets, options) {
@@ -1336,6 +1352,8 @@
       const maxValue = Math.max(0, ...teams.map((team) => team.totalValue));
       const isMobile = window.matchMedia('(max-width: 640px)').matches;
 
+      const totalsPluginOffset = isMobile ? 10 : 18;
+
       state.charts.overall = createStackedBarChart(
         elements.overallCanvas,
         labels,
@@ -1347,10 +1365,10 @@
           interaction: { mode: 'nearest', intersect: false },
           layout: {
             padding: {
-              left: isMobile ? 8 : 16,
-              right: isMobile ? 14 : 18,
-              top: 8,
-              bottom: 8,
+              left: isMobile ? 2 : 4,
+              right: isMobile ? 34 : 46,
+              top: 6,
+              bottom: 6,
             },
           },
           scales: {
@@ -1372,7 +1390,7 @@
               grid: { display: false },
               ticks: {
                 color: '#EAEBF0',
-                padding: isMobile ? 4 : 8,
+                padding: isMobile ? 1 : 2,
                 font: {
                   size: isMobile ? 10 : 12,
                   family: "'Product Sans', 'Google Sans', sans-serif",
@@ -1418,7 +1436,7 @@
             },
             analyzerBarTotals: {
               enabled: true,
-              offset: 12,
+              offset: totalsPluginOffset,
               formatter: (value) => formatNumber(value),
               mobileFont: '9px "Product Sans", "Google Sans", sans-serif',
             },
@@ -1493,6 +1511,14 @@
           responsive: true,
           maintainAspectRatio: false,
           events: [],
+          layout: {
+            padding: {
+              top: 4,
+              bottom: 4,
+              left: 4,
+              right: 4,
+            },
+          },
           elements: {
             line: { tension: 0.32 },
           },
@@ -1508,7 +1534,7 @@
               pointLabels: {
                 color: '#EAEBF0',
                 font: { size: 13, weight: '600', family: "'Product Sans', 'Google Sans', sans-serif" },
-                padding: 14,
+                padding: 6,
               },
             },
           },
@@ -1526,7 +1552,7 @@
             },
             analyzerRadarLabels: {
               font: '11px "Product Sans", "Google Sans", sans-serif',
-              offset: 20,
+              offset: 18,
             },
           },
         },
@@ -1582,9 +1608,9 @@
         .map((entry, index) => `
           <tr>
             <td>${index + 1}</td>
-            <td>${entry.name}</td>
+            <td>${abbreviateFirstName(entry.name) || '—'}</td>
             <td>${entry.nflTeam}</td>
-            <td>${entry.owner}</td>
+            <td class="owner-cell">${entry.owner}</td>
             <td>${entry.total.toFixed(1)}</td>
             <td>${entry.ppg.toFixed(1)}</td>
           </tr>

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -5920,29 +5920,38 @@ body[data-page="analyzer"] .analyzer-hero p {
 
 body[data-page="analyzer"] .analyzer-hero-controls {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
+  justify-content: start;
+}
+
+@media (min-width: 768px) {
+  body[data-page="analyzer"] .analyzer-hero-controls {
+    grid-template-columns: repeat(auto-fit, minmax(0, max-content));
+  }
 }
 
 body[data-page="analyzer"] .analyzer-control-group {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.18rem;
   background: rgba(15, 17, 38, 0.55);
   border: 1px solid rgba(118, 109, 255, 0.18);
   border-radius: 12px;
-  padding: 0.6rem 0.75rem;
+  padding: 0.45rem 0.6rem;
+  justify-self: start;
+  width: clamp(148px, 22vw, 208px);
 }
 
 body[data-page="analyzer"] .analyzer-control-group .control-label {
-  font-size: 0.58rem;
+  font-size: 0.52rem;
   text-transform: uppercase;
   letter-spacing: 0.2em;
   color: var(--color-text-secondary);
 }
 
 body[data-page="analyzer"] .analyzer-control-group .control-value {
-  font-size: 0.85rem;
+  font-size: 0.72rem;
   font-weight: 600;
   color: var(--color-text-primary);
   margin: 0;
@@ -6023,15 +6032,17 @@ body[data-page="analyzer"] .analyzer-chip .chip-meta {
   font-size: 0.78rem;
   color: var(--color-text-secondary);
   line-height: 1.35;
+  margin-top: auto;
 }
 
 body[data-page="analyzer"] .analyzer-chip--top-scorer .chip-value {
-  font-size: 1.05rem;
-  line-height: 1.25;
+  font-size: 0.96rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 body[data-page="analyzer"] .analyzer-chip--top-scorer .chip-meta {
-  font-size: 0.74rem;
+  font-size: 0.72rem;
 }
 
 @media (max-width: 640px) {
@@ -6101,7 +6112,17 @@ body[data-page="analyzer"] .analyzer-chart {
 }
 
 body[data-page="analyzer"] .analyzer-chart--radar {
-  min-height: 360px;
+  min-height: 380px;
+  padding: 0;
+}
+
+body[data-page="analyzer"] .analyzer-radar-section {
+  padding-top: 1.25rem;
+  gap: 1rem;
+}
+
+body[data-page="analyzer"] .analyzer-radar-section .analyzer-panel-body--stacked {
+  gap: 1rem;
 }
 
 body[data-page="analyzer"] .analyzer-panel-body--stacked {
@@ -6244,7 +6265,40 @@ body[data-page="analyzer"] .analyzer-leaderboard .empty-row {
   color: var(--color-text-secondary);
 }
 
+body[data-page="analyzer"] .analyzer-leaderboard table th:first-child,
+body[data-page="analyzer"] .analyzer-leaderboard table td:first-child {
+  text-align: center;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard .owner-cell {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard table td:nth-child(2) {
+  white-space: nowrap;
+}
+
+body[data-page="analyzer"] .app-header {
+  --header-control-height: 1.65rem;
+  --header-field-max-width: 140px;
+}
+
+body[data-page="analyzer"] #usernameInput {
+  font-size: 0.62rem;
+  padding: 0.16rem 0.4rem;
+}
+
+body[data-page="analyzer"] #leagueSelect {
+  font-size: 0.66rem;
+  padding: 0.22rem 1rem 0.22rem 0.4rem;
+}
+
 @media (max-width: 640px) {
+  body[data-page="analyzer"] .analyzer-control-group {
+    width: 100%;
+  }
   body[data-page="analyzer"] .analyzer-chip {
     min-height: 110px;
   }


### PR DESCRIPTION
## Summary
- abbreviate top scorer and leaderboard player names while updating summary chip labeling and anchoring chip metadata to the base of each card
- adjust stacked bar chart spacing, totals positioning, and gradient transparency to avoid overlap
- tighten radar panel, header controls, and leaderboard styling for a more compact layout, including narrower analyzer control groups with extra spacing

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d45e064880832e978535061c953d89