### PR TITLE
Streamline analyzer header and expand mobile radar

### DIFF
--- a/DHP2_DeployDraft1.2/analyzer/analyzer.html
+++ b/DHP2_DeployDraft1.2/analyzer/analyzer.html
@@ -83,16 +83,6 @@
           <h1 id="analyzer-hero-heading">League Value &amp; Production Overview</h1>
           <p>Track KTC valuations alongside real Sleeper scoring to uncover strengths across every roster.</p>
         </div>
-        <div class="analyzer-hero-controls">
-          <div class="analyzer-control-group">
-            <span class="control-label">Username</span>
-            <p class="control-value" id="activeUsername">&mdash;</p>
-          </div>
-          <div class="analyzer-control-group">
-            <span class="control-label">League</span>
-            <p class="control-value" id="activeLeague">Select a league...</p>
-          </div>
-        </div>
       </section>
 
       <section id="loading" class="analyzer-loading glass-panel hidden" role="status" aria-live="polite">
@@ -191,7 +181,7 @@
                     <th scope="col">Player</th>
                     <th scope="col" class="w-20">NFL</th>
                     <th scope="col">Owner</th>
-                    <th scope="col" class="w-24">Total FPTS</th>
+                    <th scope="col" class="w-24">FPTS</th>
                     <th scope="col" class="w-20">PPG</th>
                   </tr>
                 </thead>

--- a/DHP2_DeployDraft1.2/scripts/analyzer.js
+++ b/DHP2_DeployDraft1.2/scripts/analyzer.js
@@ -21,8 +21,6 @@
       standingsBody: document.getElementById('standingsTableBody'),
       leaderboardBody: document.getElementById('leaderboardTableBody'),
       leaderboardFilters: document.querySelectorAll('.analyzer-filter-group .filter-chip'),
-      activeUsername: document.getElementById('activeUsername'),
-      activeLeague: document.getElementById('activeLeague'),
     };
 
     const SLOT_ORDER = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
@@ -231,9 +229,11 @@
           let y = isHorizontal ? center : primaryPixel - offset;
 
           if (isHorizontal) {
-            if (x > chartArea.right - 4) {
-              ctx.textAlign = 'right';
-              x = chartArea.right - 4;
+            const layoutPadding = chart.options?.layout?.padding || 0;
+            const paddingRight = typeof layoutPadding === 'number' ? layoutPadding : layoutPadding.right || 0;
+            const maxX = chart.width - paddingRight - 4;
+            if (x > maxX) {
+              x = maxX;
             }
             y = center;
           } else {
@@ -284,7 +284,6 @@
       const leagueId = elements.leagueSelect.value;
       if (leagueId) {
         analyzeLeague(leagueId);
-        updateActiveLeagueLabel();
       }
     });
 
@@ -318,7 +317,6 @@
 
     if (initialUsername) {
       elements.usernameInput.value = initialUsername;
-      setActiveUsername(initialUsername);
       handleFetchData(initialLeagueId);
     }
 
@@ -330,7 +328,6 @@
       }
 
       setLoading(true);
-      setActiveUsername(username);
       hideContent();
 
       try {
@@ -345,14 +342,12 @@
           const target = state.leagues.find((league) => league.league_id === targetLeagueId);
           if (target) {
             elements.leagueSelect.value = targetLeagueId;
-            updateActiveLeagueLabel();
             await analyzeLeague(targetLeagueId);
             return;
           }
         }
 
         elements.leagueSelect.selectedIndex = 1;
-        updateActiveLeagueLabel();
         await analyzeLeague(state.leagues[0].league_id);
       } catch (error) {
         console.error('Analyzer fetch error:', error);
@@ -365,23 +360,6 @@
     function hideContent() {
       elements.content.classList.add('hidden');
       elements.summaryStats.classList.add('hidden');
-    }
-
-    function setActiveUsername(username) {
-      if (elements.activeUsername) {
-        elements.activeUsername.textContent = username ? `@${username}` : '—';
-      }
-    }
-
-    function updateActiveLeagueLabel() {
-      if (!elements.activeLeague) return;
-      const selectedId = elements.leagueSelect.value;
-      if (!selectedId) {
-        elements.activeLeague.textContent = 'Select a league...';
-        return;
-      }
-      const league = state.leagues.find((entry) => entry.league_id === selectedId);
-      elements.activeLeague.textContent = league ? league.name : 'Select a league...';
     }
 
     async function fetchWithCache(url) {
@@ -1007,6 +985,20 @@
       return `${i}th`;
     }
 
+    function abbreviateFirstName(fullName) {
+      if (typeof fullName !== 'string') return fullName || '';
+      const trimmed = fullName.trim();
+      if (!trimmed) return '';
+      const parts = trimmed.split(/\s+/);
+      if (parts.length === 1) {
+        return parts[0];
+      }
+      const [first, ...rest] = parts;
+      const initial = first ? `${first.charAt(0).toUpperCase()}.` : '';
+      const remainder = rest.join(' ');
+      return remainder ? `${initial} ${remainder}`.trim() : initial;
+    }
+
     function renderSummaryStats(teams) {
       const userTeam = teams.find((team) => team.isUserTeam);
       if (!userTeam) {
@@ -1015,7 +1007,8 @@
       }
 
       const totalTeams = teams.length;
-      const overallRank = computeRank(teams, (team) => team.isUserTeam);
+      const standingsOrder = sortTeamsByStandings(teams);
+      const overallRank = computeRank(standingsOrder, (team) => team.isUserTeam);
 
       const starterValueRank = computeRank(
         [...teams].sort((a, b) => b.startersValueTotal - a.startersValueTotal),
@@ -1056,7 +1049,7 @@
           accent: overallRank ? getRankColor(overallRank, totalTeams) : undefined,
         },
         {
-          label: 'Total Roster Value',
+          label: 'TTL Team Value',
           value: formatNumber(userTeam.totalValue),
           meta: 'KTC',
         },
@@ -1079,8 +1072,8 @@
           accent: starterPpgRank ? getRankColor(starterPpgRank, totalTeams) : undefined,
         },
         {
-          label: 'Top Scoring Player',
-          value: topScorer?.name || '—',
+          label: 'Top Scorer',
+          value: topScorer?.name ? abbreviateFirstName(topScorer.name) : '—',
           meta: topScorerMeta,
           accent: topScorer?.total ? 'var(--color-accent-secondary)' : undefined,
           className: 'analyzer-chip--top-scorer',
@@ -1181,10 +1174,10 @@
         interaction: { mode: 'nearest', intersect: false },
         layout: {
           padding: {
-            left: isMobile ? 8 : 16,
-            right: isMobile ? 14 : 18,
-            top: 8,
-            bottom: 8,
+            left: isMobile ? 2 : 4,
+            right: isMobile ? 34 : 46,
+            top: 6,
+            bottom: 6,
           },
         },
         scales: {
@@ -1206,7 +1199,7 @@
             grid: { display: false },
             ticks: {
               color: '#EAEBF0',
-              padding: isMobile ? 4 : 8,
+              padding: isMobile ? 1 : 2,
               font: {
                 size: isMobile ? 10 : 12,
                 family: "'Product Sans', 'Google Sans', sans-serif",
@@ -1259,7 +1252,7 @@
           },
           analyzerBarTotals: {
             enabled: true,
-            offset: 12,
+            offset: isMobile ? 10 : 18,
             formatter: (value) => formatter(value),
             mobileFont: '9px "Product Sans", "Google Sans", sans-serif',
           },
@@ -1294,7 +1287,7 @@
     }
 
     function buildGradientPair(hex) {
-      return [hexToRgba(hex, 0.92), hexToRgba(hex, 0.45)];
+      return [hexToRgba(hex, 0.8), hexToRgba(hex, 0.32)];
     }
 
     function createStackedBarChart(canvas, labels, datasets, options) {
@@ -1336,6 +1329,8 @@
       const maxValue = Math.max(0, ...teams.map((team) => team.totalValue));
       const isMobile = window.matchMedia('(max-width: 640px)').matches;
 
+      const totalsPluginOffset = isMobile ? 10 : 18;
+
       state.charts.overall = createStackedBarChart(
         elements.overallCanvas,
         labels,
@@ -1347,10 +1342,10 @@
           interaction: { mode: 'nearest', intersect: false },
           layout: {
             padding: {
-              left: isMobile ? 8 : 16,
-              right: isMobile ? 14 : 18,
-              top: 8,
-              bottom: 8,
+              left: isMobile ? 2 : 4,
+              right: isMobile ? 34 : 46,
+              top: 6,
+              bottom: 6,
             },
           },
           scales: {
@@ -1372,7 +1367,7 @@
               grid: { display: false },
               ticks: {
                 color: '#EAEBF0',
-                padding: isMobile ? 4 : 8,
+                padding: isMobile ? 1 : 2,
                 font: {
                   size: isMobile ? 10 : 12,
                   family: "'Product Sans', 'Google Sans', sans-serif",
@@ -1418,7 +1413,7 @@
             },
             analyzerBarTotals: {
               enabled: true,
-              offset: 12,
+              offset: totalsPluginOffset,
               formatter: (value) => formatNumber(value),
               mobileFont: '9px "Product Sans", "Google Sans", sans-serif',
             },
@@ -1450,6 +1445,16 @@
       const labelColors = userData.map((value, index) =>
         getPpgLabelColor(value, leagueAverages[index]),
       );
+
+      const isMobileRadar = window.matchMedia('(max-width: 640px)').matches;
+      const radarLayoutPadding = {
+        top: isMobileRadar ? 2 : 4,
+        bottom: isMobileRadar ? 4 : 4,
+        left: isMobileRadar ? 0 : 4,
+        right: isMobileRadar ? 0 : 4,
+      };
+      const radarPointLabelPadding = isMobileRadar ? 4 : 6;
+      const radarLabelOffset = isMobileRadar ? 14 : 18;
 
       if (state.charts.radar) {
         state.charts.radar.destroy();
@@ -1493,6 +1498,9 @@
           responsive: true,
           maintainAspectRatio: false,
           events: [],
+          layout: {
+            padding: radarLayoutPadding,
+          },
           elements: {
             line: { tension: 0.32 },
           },
@@ -1508,7 +1516,7 @@
               pointLabels: {
                 color: '#EAEBF0',
                 font: { size: 13, weight: '600', family: "'Product Sans', 'Google Sans', sans-serif" },
-                padding: 14,
+                padding: radarPointLabelPadding,
               },
             },
           },
@@ -1526,7 +1534,7 @@
             },
             analyzerRadarLabels: {
               font: '11px "Product Sans", "Google Sans", sans-serif',
-              offset: 20,
+              offset: radarLabelOffset,
             },
           },
         },
@@ -1534,23 +1542,12 @@
     }
 
     function renderStandings(teams) {
-      const standings = teams
-        .map((team) => ({
-          teamName: team.teamName,
-          wins: team.wins,
-          losses: team.losses,
-          ties: team.ties,
-          record: team.record,
-          pf: team.totalFpts,
-          pa: team.pointsAgainst,
-          winPct: computeWinPct(team.wins, team.losses, team.ties),
-        }))
-        .sort((a, b) => {
-          if (b.winPct !== a.winPct) return b.winPct - a.winPct;
-          if (b.wins !== a.wins) return b.wins - a.wins;
-          if (b.pf !== a.pf) return b.pf - a.pf;
-          return a.teamName.localeCompare(b.teamName);
-        });
+      const standings = sortTeamsByStandings(teams).map((team) => ({
+        teamName: team.teamName,
+        record: team.record || '—',
+        pf: Number(team.totalFpts) || 0,
+        pa: Number(team.pointsAgainst) || 0,
+      }));
 
       elements.standingsBody.innerHTML = standings
         .map((team) => `
@@ -1570,6 +1567,19 @@
       return (wins + ties * 0.5) / games;
     }
 
+    function sortTeamsByStandings(teams = []) {
+      return [...teams].sort((a, b) => {
+        const aWinPct = computeWinPct(a.wins || 0, a.losses || 0, a.ties || 0);
+        const bWinPct = computeWinPct(b.wins || 0, b.losses || 0, b.ties || 0);
+        if (bWinPct !== aWinPct) return bWinPct - aWinPct;
+        if ((b.wins || 0) !== (a.wins || 0)) return (b.wins || 0) - (a.wins || 0);
+        if ((b.totalFpts || 0) !== (a.totalFpts || 0)) return (b.totalFpts || 0) - (a.totalFpts || 0);
+        const aName = a.teamName || '';
+        const bName = b.teamName || '';
+        return aName.localeCompare(bName);
+      });
+    }
+
     function renderLeagueLeaders() {
       const position = state.activeLeaderboard;
       const leaders = state.leaderboards[position] || [];
@@ -1582,9 +1592,9 @@
         .map((entry, index) => `
           <tr>
             <td>${index + 1}</td>
-            <td>${entry.name}</td>
+            <td>${abbreviateFirstName(entry.name) || '—'}</td>
             <td>${entry.nflTeam}</td>
-            <td>${entry.owner}</td>
+            <td class="owner-cell">${truncateLabel(entry.owner, 11) || '—'}</td>
             <td>${entry.total.toFixed(1)}</td>
             <td>${entry.ppg.toFixed(1)}</td>
           </tr>

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -5918,36 +5918,6 @@ body[data-page="analyzer"] .analyzer-hero p {
   line-height: 1.6;
 }
 
-body[data-page="analyzer"] .analyzer-hero-controls {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-}
-
-body[data-page="analyzer"] .analyzer-control-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  background: rgba(15, 17, 38, 0.55);
-  border: 1px solid rgba(118, 109, 255, 0.18);
-  border-radius: 12px;
-  padding: 0.6rem 0.75rem;
-}
-
-body[data-page="analyzer"] .analyzer-control-group .control-label {
-  font-size: 0.58rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  color: var(--color-text-secondary);
-}
-
-body[data-page="analyzer"] .analyzer-control-group .control-value {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  margin: 0;
-}
-
 body[data-page="analyzer"] .analyzer-loading {
   display: flex;
   align-items: center;
@@ -6023,15 +5993,17 @@ body[data-page="analyzer"] .analyzer-chip .chip-meta {
   font-size: 0.78rem;
   color: var(--color-text-secondary);
   line-height: 1.35;
+  margin-top: auto;
 }
 
 body[data-page="analyzer"] .analyzer-chip--top-scorer .chip-value {
-  font-size: 1.05rem;
-  line-height: 1.25;
+  font-size: 0.96rem;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 body[data-page="analyzer"] .analyzer-chip--top-scorer .chip-meta {
-  font-size: 0.74rem;
+  font-size: 0.72rem;
 }
 
 @media (max-width: 640px) {
@@ -6101,7 +6073,24 @@ body[data-page="analyzer"] .analyzer-chart {
 }
 
 body[data-page="analyzer"] .analyzer-chart--radar {
-  min-height: 360px;
+  min-height: 380px;
+  padding: 0;
+}
+
+body[data-page="analyzer"] .analyzer-radar-section {
+  padding-top: 1.25rem;
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  body[data-page="analyzer"] .analyzer-radar-section {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+
+body[data-page="analyzer"] .analyzer-radar-section .analyzer-panel-body--stacked {
+  gap: 1rem;
 }
 
 body[data-page="analyzer"] .analyzer-panel-body--stacked {
@@ -6242,6 +6231,43 @@ body[data-page="analyzer"] .analyzer-leaderboard .empty-row {
   text-align: center;
   padding: 1.5rem 0;
   color: var(--color-text-secondary);
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard table th:first-child,
+body[data-page="analyzer"] .analyzer-leaderboard table td:first-child {
+  text-align: center;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard table th:nth-child(5),
+body[data-page="analyzer"] .analyzer-leaderboard table td:nth-child(5),
+body[data-page="analyzer"] .analyzer-leaderboard table th:nth-child(6),
+body[data-page="analyzer"] .analyzer-leaderboard table td:nth-child(6) {
+  text-align: center;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard .owner-cell {
+  font-size: 0.78rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+body[data-page="analyzer"] .analyzer-leaderboard table td:nth-child(2) {
+  white-space: nowrap;
+}
+
+body[data-page="analyzer"] .app-header {
+  --header-control-height: 1.65rem;
+  --header-field-max-width: 140px;
+}
+
+body[data-page="analyzer"] #usernameInput {
+  font-size: 0.62rem;
+  padding: 0.16rem 0.4rem;
+}
+
+body[data-page="analyzer"] #leagueSelect {
+  font-size: 0.66rem;
+  padding: 0.22rem 1rem 0.22rem 0.4rem;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- remove the analyzer hero metadata display blocks and associated scripting now that the header no longer mirrors username/league selections
- adjust the radar chart options to shrink horizontal padding, label offsets, and spacing on phones so the visualization fills more of the panel
- trim the radar panel padding on narrow screens to free up additional width for the canvas

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d45e064880832e978535061c953d89