### PR TITLE
Move player vitals above summary chips in compare modal

### DIFF
--- a/DHP2_DeployDraft1.2/scripts/app.js
+++ b/DHP2_DeployDraft1.2/scripts/app.js
@@ -2177,8 +2177,6 @@ const SEASON_META_HEADERS = {
 
                 nameHeader.appendChild(nameButton);
                 nameHeader.appendChild(tagsRow);
-                const compareVitals = createPlayerVitalsElement(getPlayerVitals(player.id), { variant: 'compare' });
-                nameHeader.appendChild(compareVitals);
                 headerContainer.appendChild(nameHeader);
 
                 playerNamesRow.appendChild(headerContainer);
@@ -2192,6 +2190,7 @@ const SEASON_META_HEADERS = {
             players.forEach(player => {
                 const summaryChipsContainer = document.createElement('div');
                 summaryChipsContainer.className = 'summary-chips-container';
+                const compareVitals = createPlayerVitalsElement(getPlayerVitals(player.id), { variant: 'compare' });
 
                 const overallRankNumber = typeof player.overallRank === 'number' ? player.overallRank : Number(player.overallRank);
                 const overallRankDisplay = Number.isFinite(overallRankNumber)
@@ -2257,6 +2256,7 @@ const SEASON_META_HEADERS = {
                     </div>
                   </div>
                 `;
+                summaryChipsContainer.insertAdjacentElement('afterbegin', compareVitals);
                 summaryChipsRow.appendChild(summaryChipsContainer);
             });
 

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -3623,6 +3623,11 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         flex-direction: column;
         gap: 0.2rem;
     }
+
+    #player-comparison-modal .summary-chips-container .player-vitals--compare {
+        width: 100%;
+        box-sizing: border-box;
+    }
     
     /* · · Player Comp Table · · */
     .player-comparison-table { 


### PR DESCRIPTION
## Summary
- relocate the player vitals block in the compare modal so it renders above the summary chips for each player
- ensure the vitals span the full width of the summary section to align with the FPTS chip

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d470325ccc832e834ac73ebcc8c9aa