### PR TITLE
Force compare vitals to match summary chip width

### DIFF
--- a/DHP2_DeployDraft1.2/scripts/app.js
+++ b/DHP2_DeployDraft1.2/scripts/app.js
@@ -46,6 +46,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const modalBody = document.getElementById('modal-body');
         const playerComparisonModal = document.getElementById('player-comparison-modal');
         const comparisonBackgroundOverlay = document.getElementById('comparison-modal-background-overlay');
+        let teardownCompareVitalsSizing = null;
 
         const COMPARE_BUTTON_PREVIEW_HTML = '<span class="button-text">Preview</span>';
         const COMPARE_BUTTON_SHOW_ALL_HTML = '<span class="compare-show-all-stack"><i aria-hidden="true" class="fa-solid fa-arrows-left-right-to-line compare-show-all-icon"></i><span class="compare-show-all-label">Show All</span></span>';
@@ -2067,6 +2068,10 @@ const SEASON_META_HEADERS = {
 
         function renderPlayerComparison(players) {
             const comparisonModalBody = document.getElementById('comparison-modal-body');
+            if (typeof teardownCompareVitalsSizing === 'function') {
+                teardownCompareVitalsSizing();
+                teardownCompareVitalsSizing = null;
+            }
             comparisonModalBody.innerHTML = ''; // Clear existing content
 
             const container = document.createElement('div');
@@ -2177,8 +2182,6 @@ const SEASON_META_HEADERS = {
 
                 nameHeader.appendChild(nameButton);
                 nameHeader.appendChild(tagsRow);
-                const compareVitals = createPlayerVitalsElement(getPlayerVitals(player.id), { variant: 'compare' });
-                nameHeader.appendChild(compareVitals);
                 headerContainer.appendChild(nameHeader);
 
                 playerNamesRow.appendChild(headerContainer);
@@ -2192,6 +2195,7 @@ const SEASON_META_HEADERS = {
             players.forEach(player => {
                 const summaryChipsContainer = document.createElement('div');
                 summaryChipsContainer.className = 'summary-chips-container';
+                const compareVitals = createPlayerVitalsElement(getPlayerVitals(player.id), { variant: 'compare' });
 
                 const overallRankNumber = typeof player.overallRank === 'number' ? player.overallRank : Number(player.overallRank);
                 const overallRankDisplay = Number.isFinite(overallRankNumber)
@@ -2257,6 +2261,7 @@ const SEASON_META_HEADERS = {
                     </div>
                   </div>
                 `;
+                summaryChipsContainer.insertAdjacentElement('afterbegin', compareVitals);
                 summaryChipsRow.appendChild(summaryChipsContainer);
             });
 
@@ -2584,6 +2589,21 @@ const SEASON_META_HEADERS = {
 
             container.appendChild(tableContainer);
             comparisonModalBody.appendChild(container);
+
+            const alignVitalsWidths = () => alignCompareVitalsWidths(summaryChipsRow);
+            const scheduleAlignment = () => {
+                requestAnimationFrame(() => {
+                    alignVitalsWidths();
+                    requestAnimationFrame(alignVitalsWidths);
+                });
+            };
+            scheduleAlignment();
+            window.addEventListener('resize', alignVitalsWidths);
+            const delayedAlignTimeout = window.setTimeout(alignVitalsWidths, 160);
+            teardownCompareVitalsSizing = () => {
+                window.removeEventListener('resize', alignVitalsWidths);
+                window.clearTimeout(delayedAlignTimeout);
+            };
 
             const footer = playerComparisonModal.querySelector('.modal-footer');
             const keyContainer = document.getElementById('comparison-stats-key-container');
@@ -3450,6 +3470,27 @@ const SEASON_META_HEADERS = {
             return container;
         }
 
+        function alignCompareVitalsWidths(root = document) {
+            const summaryContainers = root.querySelectorAll('.summary-chips-container');
+            summaryContainers.forEach(container => {
+                const vitals = container.querySelector('.player-vitals--compare');
+                if (!vitals) {
+                    return;
+                }
+                const firstChip = container.querySelector('.summary-chip');
+                if (!firstChip) {
+                    vitals.style.width = '';
+                    return;
+                }
+                const { width } = firstChip.getBoundingClientRect();
+                if (width > 0) {
+                    vitals.style.width = `${width}px`;
+                } else {
+                    vitals.style.width = '';
+                }
+            });
+        }
+
         function getRankColor(rank) {
             if (typeof rank !== 'number') return 'var(--color-text-primary)';
             const thresholds = [
@@ -3607,6 +3648,10 @@ const SEASON_META_HEADERS = {
                 playerComparisonModal.classList.add('hidden');
                 if (comparisonBackgroundOverlay) {
                     comparisonBackgroundOverlay.classList.add('hidden');
+                }
+                if (typeof teardownCompareVitalsSizing === 'function') {
+                    teardownCompareVitalsSizing();
+                    teardownCompareVitalsSizing = null;
                 }
                 const comparisonModalBody = document.getElementById('comparison-modal-body');
                 if (comparisonModalBody) {

--- a/DHP2_DeployDraft1.2/styles/styles.css
+++ b/DHP2_DeployDraft1.2/styles/styles.css
@@ -3144,20 +3144,21 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
     
 
     .player-vitals--compare {
-      margin-top: 0.18rem;
-    gap: 1.3rem;
-    border-radius: 8px;
-    border: 1px solid #fff2;
-    padding: 3px 7px;
+      margin: 0.08rem auto 0;
+      gap: 0.8rem;
+      border-radius: 8px;
+      border: 1px solid #fff2;
+      padding: 2px 6px;
+      align-self: center;
     }
 
     .player-vitals--compare .player-vitals__label {
-      font-size: 0.45rem;
-      letter-spacing: 0.16em;
+      font-size: 0.38rem;
+      letter-spacing: 0.14em;
     }
 
     .player-vitals--compare .player-vitals__value {
-      font-size: 0.75rem;
+      font-size: 0.68rem;
     }
     
     #modal-summary-row {
@@ -3623,7 +3624,6 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         flex-direction: column;
         gap: 0.2rem;
     }
-    
     /* · · Player Comp Table · · */
     .player-comparison-table { 
         width: 100%;


### PR DESCRIPTION
## Summary
- ensure the compare-modal vitals clean up any prior sizing listeners before rebuilding the modal
- measure the FPTS summary chip and force the vitals block to share its width with resize-safe scheduling
- remove the resize listener and timeout when the comparison modal is closed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d470325ccc832e834ac73ebcc8c9aa