### PR TITLE
Adjust draft chips and add trade close control

### DIFF
--- a/DHP2_DeployDraft1.51/scripts/app.js
+++ b/DHP2_DeployDraft1.51/scripts/app.js
@@ -759,6 +759,15 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             closeComparisonModal();
         }
 
+        function handleCloseTradePreview() {
+            const keepUserTeam = Boolean(state.userTeamName && state.teamsToCompare.has(state.userTeamName));
+            handleClearCompare(keepUserTeam);
+            state.isTradeCollapsed = true;
+            if (tradeSimulator) {
+                tradeSimulator.classList.add('collapsed');
+            }
+        }
+
 
         // --- Position Filter Logic ---
         function handleClearFilters() {
@@ -2957,6 +2966,10 @@ const SEASON_META_HEADERS = {
               <i class="fa-solid fa-eraser"></i>
               <span class="label">Clear</span>
             </button>
+              <button id="closeTradeButton" type="button">
+              <i class="fa-solid fa-circle-xmark"></i>
+              <span class="label">Close</span>
+            </button>
             </div>
           </div>
         
@@ -3053,6 +3066,7 @@ const SEASON_META_HEADERS = {
             tradeSimulator.classList.toggle('collapsed', state.isTradeCollapsed);
 
             document.getElementById('clearTradeButton').addEventListener('click', clearTrade);
+            document.getElementById('closeTradeButton').addEventListener('click', handleCloseTradePreview);
             document.getElementById('collapseTradeButton').addEventListener('click', () => {
                 tradeSimulator.classList.add('collapsed');
                 state.isTradeCollapsed = true;

--- a/DHP2_DeployDraft1.51/scripts/syop.js
+++ b/DHP2_DeployDraft1.51/scripts/syop.js
@@ -137,13 +137,6 @@
     { key: 'WR', color: '#46E7FF' }
   ];
 
-  const SERIES_LABEL_OFFSETS = {
-    QB: {},
-    RB: {},
-    TE: {},
-    WR: {}
-  };
-
   const SERIES_CONFIG = [
     { key: 'QB %', label: 'QB %', color: colors.qb },
     { key: 'RB %', label: 'RB %', color: colors.rb },
@@ -1178,11 +1171,11 @@
     const containerWidth = container.clientWidth || 0;
     const fallbackWidth = 360;
     const width = containerWidth > 0 ? containerWidth : fallbackWidth;
-    const height = width < 540 ? 300 : 360;
+    const height = width < 540 ? 400 : 460;
     const isCompact = width < 560;
     const margin = width < 540
-      ? { top: 52, right: 20, bottom: 48, left: 54 }
-      : { top: 52, right: 28, bottom: 56, left: 68 };
+      ? { top: 52, right: 20, bottom: 148, left: 54 }
+      : { top: 52, right: 28, bottom: 156, left: 68 };
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
     const svg = createSVG('svg', {
@@ -1228,7 +1221,6 @@
     });
 
     const dotRadius = isCompact ? 3.6 : 4.4;
-    const labelEntries = [];
     const roundLabelGroups = rounds.map(() => []);
 
     DRAFT_SERIES.forEach((series) => {
@@ -1248,10 +1240,6 @@
       });
       g.appendChild(path);
 
-      const offsetConfig = SERIES_LABEL_OFFSETS[series.key] || null;
-      const labelAnchor = offsetConfig?.anchor || 'middle';
-      const offsetX = offsetConfig?.dx || 0;
-
       points.forEach((point) => {
         g.appendChild(createSVG('circle', {
           cx: point.x,
@@ -1262,97 +1250,61 @@
           'stroke-width': '2'
         }));
 
-        const entry = {
+        roundLabelGroups[point.roundIndex].push({
           series,
-          point,
-          offsetX,
-          anchor: labelAnchor,
-          text: `${point.value}%`,
           value: point.value,
-          offsetY: 0
-        };
-
-        labelEntries.push(entry);
-        roundLabelGroups[point.roundIndex].push(entry);
-      });
-    });
-
-    const labelFontSize = isCompact ? 9.5 : 10.5;
-    const labelPadding = { x: 5, y: 3 };
-    const labelHeight = labelFontSize + 2 * labelPadding.y;
-    const verticalGap = 4;
-
-    roundLabelGroups.forEach(entries => {
-      if (entries.length < 2) return;
-
-      const sorted = entries.slice().sort((a, b) => a.point.y - b.point.y);
-      const clusters = [];
-      if (sorted.length > 0) {
-        let currentCluster = [sorted[0]];
-        clusters.push(currentCluster);
-
-        for (let i = 1; i < sorted.length; i++) {
-          if (sorted[i].point.y - sorted[i - 1].point.y < labelHeight * 1.25) {
-            currentCluster.push(sorted[i]);
-          } else {
-            currentCluster = [sorted[i]];
-            clusters.push(currentCluster);
-          }
-        }
-      }
-
-      clusters.forEach(cluster => {
-        if (cluster.length < 2) return;
-
-        const clusterMidY = cluster.reduce((sum, e) => sum + e.point.y, 0) / cluster.length;
-        const totalHeight = cluster.length * labelHeight + (cluster.length - 1) * verticalGap;
-        let startY = clusterMidY - totalHeight / 2;
-
-        cluster.forEach(entry => {
-          entry.finalY = startY + labelHeight / 2;
-          startY += labelHeight + verticalGap;
-          entry.offsetY = entry.finalY - entry.point.y;
+          point
         });
       });
     });
 
-    labelEntries.forEach(entry => {
-      const textWidth = entry.text.length * labelFontSize * 0.58 + 4;
-      const rectWidth = textWidth + 2 * labelPadding.x;
-      const rectHeight = labelHeight;
-      const yPos = entry.point.y + (entry.offsetY || 0);
+    const chipFontSize = isCompact ? 9.5 : 10.5;
+    const chipPadding = { x: 6, y: 4 };
+    const chipHeight = chipFontSize + 2 * chipPadding.y;
+    const chipGap = isCompact ? 4 : 6;
+    const chipStartY = chartHeight + (isCompact ? 42 : 44);
 
-      const labelGroup = createSVG('g', {
-        transform: `translate(${entry.point.x}, ${yPos})`,
-        class: 'draft-label-chip'
+    roundLabelGroups.forEach((entries) => {
+      const sorted = entries.slice().sort((a, b) => b.value - a.value);
+      sorted.forEach((entry, index) => {
+        const text = `${entry.value}%`;
+        const textWidth = text.length * chipFontSize * 0.58 + 4;
+        const rectWidth = textWidth + 2 * chipPadding.x;
+        const rectHeight = chipHeight;
+        const yPos = chipStartY + index * (rectHeight + chipGap);
+
+        const labelGroup = createSVG('g', {
+          transform: `translate(${entry.point.x}, ${yPos})`,
+          class: 'draft-label-chip'
+        });
+
+        labelGroup.appendChild(createSVG('rect', {
+          x: -rectWidth / 2,
+          y: -rectHeight / 2,
+          width: rectWidth,
+          height: rectHeight,
+          rx: 5,
+          ry: 5,
+          fill: hexToRgba(colors.bg, 0.4),
+          stroke: hexToRgba(entry.series.color, 0.55),
+          'stroke-width': '1.5'
+        }));
+
+        labelGroup.appendChild(createSVG('text', {
+          x: 0,
+          y: 0,
+          fill: entry.series.color,
+          'font-size': `${chipFontSize}px`,
+          'font-weight': '700',
+          'text-anchor': 'middle',
+          'dominant-baseline': 'central',
+          'paint-order': 'stroke',
+          stroke: 'rgba(11, 14, 22, 0.85)',
+          'stroke-width': '2.5',
+          'stroke-linecap': 'round'
+        }, document.createTextNode(text)));
+        g.appendChild(labelGroup);
       });
-
-      labelGroup.appendChild(createSVG('rect', {
-        x: -rectWidth / 2,
-        y: -rectHeight / 2,
-        width: rectWidth,
-        height: rectHeight,
-        rx: 5,
-        ry: 5,
-        fill: hexToRgba(colors.bg, 0.4),
-        stroke: hexToRgba(entry.series.color, 0.55),
-        'stroke-width': '1.5'
-      }));
-
-      labelGroup.appendChild(createSVG('text', {
-        x: 0,
-        y: 0,
-        fill: entry.series.color,
-        'font-size': `${labelFontSize}px`,
-        'font-weight': '700',
-        'text-anchor': 'middle',
-        'dominant-baseline': 'central',
-        'paint-order': 'stroke',
-        stroke: 'rgba(11, 14, 22, 0.85)',
-        'stroke-width': '2.5',
-        'stroke-linecap': 'round'
-      }, document.createTextNode(entry.text)));
-      g.appendChild(labelGroup);
     });
 
     g.appendChild(createSVG('line', {

--- a/DHP2_DeployDraft1.51/styles/styles.css
+++ b/DHP2_DeployDraft1.51/styles/styles.css
@@ -1163,7 +1163,8 @@
         }
         
     /* · · ↻ CLEAR Trade Button · · */
-        #clearTradeButton {
+        #clearTradeButton,
+        #closeTradeButton {
           display: flex;
           flex-direction: column;    /* icon on top, label below */
           align-items: center;
@@ -1181,16 +1182,18 @@
           border-radius: 6px;
           min-height: 0;
         }
-        
-        #clearTradeButton i {
+
+        #clearTradeButton i,
+        #closeTradeButton i {
           display: block;
           margin: 0;
           line-height: 1;
           font-size: 1rem;        /* tweak to match compare button icon weight */
         }
-        
+
         /* Label — pulled up to visually touch the icon */
-        #clearTradeButton .label {
+        #clearTradeButton .label,
+        #closeTradeButton .label {
           display: block;
           margin: -2px 0 0 0;        /* pull label up; adjust -1 / -3 px if needed */
           padding: 0;
@@ -1199,10 +1202,11 @@
           line-height: 1;
           color: inherit;
         }
-        
-        
-        
-        #clearTradeButton:hover {
+
+
+
+        #clearTradeButton:hover,
+        #closeTradeButton:hover {
             color: var(--color-text-secondary);
             border-color: var(--color-panel-border-glow);
         }


### PR DESCRIPTION
## Summary
- Reworked the NFL Draft positional trends chart to place sorted percentage chips beneath each round axis label.
- Added a Close control to the trade preview that keeps only the user team selected while clearing assets, and styled it to match the Clear button.

## Testing
- No automated tests were run (not available).


------
https://chatgpt.com/codex/tasks/task_e_68d4acef2668832e8b8c704467df2e97