### PR TITLE
Align draft positional chart layout and legend

### DIFF
--- a/DHP2_DeployDraft1.51/research/research.html
+++ b/DHP2_DeployDraft1.51/research/research.html
@@ -187,7 +187,7 @@
           <article class="syop-panel glass-panel" id="draft-positional-panel">
             <header>
               <h3>Positional Hit Rate Trends by Round</h3>
-              <p>Exact percentages by position and draft round</p>
+              <div class="syop-line-legend" id="draft-positional-legend" role="group" aria-label="Positional hit rate legend"></div>
             </header>
             <div class="syop-panel-body">
               <div class="syop-chart" id="draft-positional-chart" role="img" aria-label="Positional draft hit rate line chart"></div>

--- a/DHP2_DeployDraft1.51/scripts/app.js
+++ b/DHP2_DeployDraft1.51/scripts/app.js
@@ -2949,14 +2949,18 @@ const SEASON_META_HEADERS = {
               <button id="collapseTradeButton"><i class="fa-solid fa-caret-down"></i></button>
             </div>
             <div class="trade-header-right">
-            <button id="comparePlayersButton" class="control-button-subtle">
-              <i class="fa-solid fa-chart-simple"></i>
-              <span class="label">Compare</span>
-            </button>
+              <button id="comparePlayersButton" class="control-button-subtle">
+                <i class="fa-solid fa-chart-simple"></i>
+                <span class="label">Compare</span>
+              </button>
               <button id="clearTradeButton" type="button">
-              <i class="fa-solid fa-eraser"></i>
-              <span class="label">Clear</span>
-            </button>
+                <i class="fa-solid fa-eraser"></i>
+                <span class="label">Clear</span>
+              </button>
+              <button id="closeTradeButton" type="button">
+                <i class="fa-solid fa-circle-xmark"></i>
+                <span class="label">Close</span>
+              </button>
             </div>
           </div>
         
@@ -3052,7 +3056,13 @@ const SEASON_META_HEADERS = {
 
             tradeSimulator.classList.toggle('collapsed', state.isTradeCollapsed);
 
-            document.getElementById('clearTradeButton').addEventListener('click', clearTrade);
+            if (clearBtn) {
+                clearBtn.addEventListener('click', clearTrade);
+            }
+            const closeTradeButton = document.getElementById('closeTradeButton');
+            if (closeTradeButton) {
+                closeTradeButton.addEventListener('click', () => handleClearCompare(true));
+            }
             document.getElementById('collapseTradeButton').addEventListener('click', () => {
                 tradeSimulator.classList.add('collapsed');
                 state.isTradeCollapsed = true;

--- a/DHP2_DeployDraft1.51/scripts/syop.js
+++ b/DHP2_DeployDraft1.51/scripts/syop.js
@@ -137,13 +137,6 @@
     { key: 'WR', color: '#46E7FF' }
   ];
 
-  const SERIES_LABEL_OFFSETS = {
-    QB: {},
-    RB: {},
-    TE: {},
-    WR: {}
-  };
-
   const SERIES_CONFIG = [
     { key: 'QB %', label: 'QB %', color: colors.qb },
     { key: 'RB %', label: 'RB %', color: colors.rb },
@@ -1166,23 +1159,37 @@
     if (!container) return;
     container.innerHTML = '';
 
-    const legend = createEl('div', { class: 'syop-line-legend' });
+    const legendHost = document.getElementById('draft-positional-legend');
+    let legendTarget = legendHost || null;
+    if (!legendTarget) {
+      legendTarget = createEl('div', { class: 'syop-line-legend' });
+      container.appendChild(legendTarget);
+    } else {
+      legendTarget.innerHTML = '';
+    }
+
+    if (!legendTarget.getAttribute('role')) {
+      legendTarget.setAttribute('role', 'group');
+    }
+    if (!legendTarget.getAttribute('aria-label')) {
+      legendTarget.setAttribute('aria-label', 'Positional hit rate legend');
+    }
+
     DRAFT_SERIES.forEach((series) => {
-      legend.appendChild(createEl('span', { class: 'legend-item' },
+      legendTarget.appendChild(createEl('span', { class: 'legend-item' },
         createEl('span', { class: 'legend-swatch', style: { backgroundColor: series.color } }),
         createEl('span', { class: 'legend-label' }, series.key)
       ));
     });
-    container.appendChild(legend);
 
     const containerWidth = container.clientWidth || 0;
     const fallbackWidth = 360;
     const width = containerWidth > 0 ? containerWidth : fallbackWidth;
-    const height = width < 540 ? 300 : 360;
-    const isCompact = width < 560;
-    const margin = width < 540
-      ? { top: 52, right: 20, bottom: 48, left: 54 }
-      : { top: 52, right: 28, bottom: 56, left: 68 };
+    const isCompact = width < 520;
+    const height = isCompact ? 270 : 320;
+    const margin = isCompact
+      ? { top: 26, right: 14, bottom: 48, left: 46 }
+      : { top: 32, right: 24, bottom: 56, left: 60 };
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
     const svg = createSVG('svg', {
@@ -1220,7 +1227,7 @@
       const x = index * stepX;
       g.appendChild(createSVG('text', {
         x,
-        y: chartHeight + 28,
+        y: chartHeight + 26,
         fill: colors.subtext,
         'font-size': '12',
         'text-anchor': 'middle'
@@ -1228,8 +1235,6 @@
     });
 
     const dotRadius = isCompact ? 3.6 : 4.4;
-    const labelEntries = [];
-    const roundLabelGroups = rounds.map(() => []);
 
     DRAFT_SERIES.forEach((series) => {
       const points = DRAFT_POSITIONAL.map((row, index) => ({
@@ -1248,10 +1253,6 @@
       });
       g.appendChild(path);
 
-      const offsetConfig = SERIES_LABEL_OFFSETS[series.key] || null;
-      const labelAnchor = offsetConfig?.anchor || 'middle';
-      const offsetX = offsetConfig?.dx || 0;
-
       points.forEach((point) => {
         g.appendChild(createSVG('circle', {
           cx: point.x,
@@ -1259,100 +1260,9 @@
           r: String(dotRadius),
           fill: colors.bg,
           stroke: series.color,
-          'stroke-width': '2'
-        }));
-
-        const entry = {
-          series,
-          point,
-          offsetX,
-          anchor: labelAnchor,
-          text: `${point.value}%`,
-          value: point.value,
-          offsetY: 0
-        };
-
-        labelEntries.push(entry);
-        roundLabelGroups[point.roundIndex].push(entry);
-      });
-    });
-
-    const labelFontSize = isCompact ? 9.5 : 10.5;
-    const labelPadding = { x: 5, y: 3 };
-    const labelHeight = labelFontSize + 2 * labelPadding.y;
-    const verticalGap = 4;
-
-    roundLabelGroups.forEach(entries => {
-      if (entries.length < 2) return;
-
-      const sorted = entries.slice().sort((a, b) => a.point.y - b.point.y);
-      const clusters = [];
-      if (sorted.length > 0) {
-        let currentCluster = [sorted[0]];
-        clusters.push(currentCluster);
-
-        for (let i = 1; i < sorted.length; i++) {
-          if (sorted[i].point.y - sorted[i - 1].point.y < labelHeight * 1.25) {
-            currentCluster.push(sorted[i]);
-          } else {
-            currentCluster = [sorted[i]];
-            clusters.push(currentCluster);
-          }
-        }
-      }
-
-      clusters.forEach(cluster => {
-        if (cluster.length < 2) return;
-
-        const clusterMidY = cluster.reduce((sum, e) => sum + e.point.y, 0) / cluster.length;
-        const totalHeight = cluster.length * labelHeight + (cluster.length - 1) * verticalGap;
-        let startY = clusterMidY - totalHeight / 2;
-
-        cluster.forEach(entry => {
-          entry.finalY = startY + labelHeight / 2;
-          startY += labelHeight + verticalGap;
-          entry.offsetY = entry.finalY - entry.point.y;
-        });
-      });
-    });
-
-    labelEntries.forEach(entry => {
-      const textWidth = entry.text.length * labelFontSize * 0.58 + 4;
-      const rectWidth = textWidth + 2 * labelPadding.x;
-      const rectHeight = labelHeight;
-      const yPos = entry.point.y + (entry.offsetY || 0);
-
-      const labelGroup = createSVG('g', {
-        transform: `translate(${entry.point.x}, ${yPos})`,
-        class: 'draft-label-chip'
-      });
-
-      labelGroup.appendChild(createSVG('rect', {
-        x: -rectWidth / 2,
-        y: -rectHeight / 2,
-        width: rectWidth,
-        height: rectHeight,
-        rx: 5,
-        ry: 5,
-        fill: hexToRgba(colors.bg, 0.4),
-        stroke: hexToRgba(entry.series.color, 0.55),
-        'stroke-width': '1.5'
+        'stroke-width': '2'
       }));
-
-      labelGroup.appendChild(createSVG('text', {
-        x: 0,
-        y: 0,
-        fill: entry.series.color,
-        'font-size': `${labelFontSize}px`,
-        'font-weight': '700',
-        'text-anchor': 'middle',
-        'dominant-baseline': 'central',
-        'paint-order': 'stroke',
-        stroke: 'rgba(11, 14, 22, 0.85)',
-        'stroke-width': '2.5',
-        'stroke-linecap': 'round'
-      }, document.createTextNode(entry.text)));
-      g.appendChild(labelGroup);
+      });
     });
 
     g.appendChild(createSVG('line', {
@@ -1364,6 +1274,41 @@
     }));
 
     container.appendChild(svg);
+
+    const chipWrapper = createEl('div', { class: 'draft-round-chip-wrapper' });
+    const chipGrid = createEl('div', { class: 'draft-round-chip-grid' });
+    chipGrid.style.setProperty('--round-count', String(rounds.length));
+    chipGrid.style.gridTemplateColumns = `repeat(${rounds.length}, minmax(0, 1fr))`;
+    chipGrid.style.maxWidth = `${width}px`;
+    chipWrapper.appendChild(chipGrid);
+
+    DRAFT_POSITIONAL.forEach((row) => {
+      const column = createEl('div', { class: 'draft-round-chip-column' });
+      const entries = DRAFT_SERIES
+        .map((series) => ({
+          series,
+          value: row[series.key] ?? 0
+        }))
+        .sort((a, b) => b.value - a.value);
+
+      entries.forEach(({ series, value }) => {
+        const chip = createEl('div', {
+          class: 'draft-round-chip',
+          style: {
+            borderColor: hexToRgba(series.color, 0.35),
+            background: hexToRgba(series.color, 0.12),
+            color: series.color
+          }
+        },
+        createEl('span', { class: 'chip-pos' }, series.key),
+        createEl('span', { class: 'chip-value' }, `${value}%`));
+        column.appendChild(chip);
+      });
+
+      chipGrid.appendChild(column);
+    });
+
+    container.appendChild(chipWrapper);
   }
 
   function handleResize() {

--- a/DHP2_DeployDraft1.51/styles/styles.css
+++ b/DHP2_DeployDraft1.51/styles/styles.css
@@ -1163,7 +1163,8 @@
         }
         
     /* · · ↻ CLEAR Trade Button · · */
-        #clearTradeButton {
+        #clearTradeButton,
+        #closeTradeButton {
           display: flex;
           flex-direction: column;    /* icon on top, label below */
           align-items: center;
@@ -1182,15 +1183,17 @@
           min-height: 0;
         }
         
-        #clearTradeButton i {
+        #clearTradeButton i,
+        #closeTradeButton i {
           display: block;
           margin: 0;
           line-height: 1;
           font-size: 1rem;        /* tweak to match compare button icon weight */
         }
-        
+
         /* Label — pulled up to visually touch the icon */
-        #clearTradeButton .label {
+        #clearTradeButton .label,
+        #closeTradeButton .label {
           display: block;
           margin: -2px 0 0 0;        /* pull label up; adjust -1 / -3 px if needed */
           padding: 0;
@@ -1199,10 +1202,11 @@
           line-height: 1;
           color: inherit;
         }
-        
-        
-        
-        #clearTradeButton:hover {
+
+
+
+        #clearTradeButton:hover,
+        #closeTradeButton:hover {
             color: var(--color-text-secondary);
             border-color: var(--color-panel-border-glow);
         }
@@ -4764,6 +4768,15 @@ body[data-page="research"] .app-header {
   font-size: 0.86rem;
 }
 
+#draft-positional-panel header .syop-line-legend {
+  margin: 0.22rem 0 0.55rem;
+  gap: 0.75rem;
+}
+
+#draft-positional-panel header .syop-line-legend .legend-item {
+  font-size: 0.82rem;
+}
+
 .syop-draft-hero {
   margin-bottom: 1.35rem;
   gap: 0.9rem 1.45rem;
@@ -5115,6 +5128,7 @@ body[data-page="research"] .app-header {
   display: none;
 }
 
+
 .syop-line-legend {
   display: flex;
   flex-wrap: wrap;
@@ -5134,6 +5148,54 @@ body[data-page="research"] .app-header {
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 999px;
+}
+
+.draft-round-chip-wrapper {
+  margin-top: 0.65rem;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.draft-round-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--round-count, 1), minmax(0, 1fr));
+  gap: 0.75rem;
+  width: 100%;
+  margin: 0 auto;
+  justify-items: center;
+}
+
+.draft-round-chip-column {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.draft-round-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 6px 12px rgba(9, 11, 24, 0.28);
+  background: rgba(70, 231, 255, 0.08);
+}
+
+.draft-round-chip .chip-pos {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+}
+
+.draft-round-chip .chip-value {
+  font-weight: 700;
 }
 
 .draft-round-tiles {
@@ -5257,6 +5319,15 @@ body[data-page="research"] .app-header {
   .syop-hero-meta {
     gap: 0.28rem;
     align-items: center;
+  }
+
+  .draft-round-chip-grid {
+    gap: 0.55rem;
+  }
+
+  .draft-round-chip {
+    font-size: 0.65rem;
+    padding: 0.26rem 0.5rem;
   }
 
   .syop-hero-meta-item {


### PR DESCRIPTION
## Summary
- replace the positional hit rate data point chips with sorted round chips rendered below the x-axis with softened styling
- move the positional legend into the panel header and align the draft charts so their axes line up on desktop
- add a Close button to the trade preview that resets compare state and clears selections

## Testing
- Not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d4ad44f194832ea4fa8d1a09ad0710