### PR TITLE
Refine draft chips for mobile

### DIFF
--- a/DHP2_DeployDraft1.51/research/research.html
+++ b/DHP2_DeployDraft1.51/research/research.html
@@ -187,7 +187,7 @@
           <article class="syop-panel glass-panel" id="draft-positional-panel">
             <header>
               <h3>Positional Hit Rate Trends by Round</h3>
-              <p>Exact percentages by position and draft round</p>
+              <div class="syop-panel-subhead" id="draft-positional-legend"></div>
             </header>
             <div class="syop-panel-body">
               <div class="syop-chart" id="draft-positional-chart" role="img" aria-label="Positional draft hit rate line chart"></div>

--- a/DHP2_DeployDraft1.51/scripts/syop.js
+++ b/DHP2_DeployDraft1.51/scripts/syop.js
@@ -137,6 +137,12 @@
     { key: 'WR', color: '#46E7FF' }
   ];
 
+  const DRAFT_OVERALL_MAX = Math.max(...DRAFT_OVERALL.map((row) => row.hit));
+  const DRAFT_POSITIONAL_MAX = Math.max(
+    ...DRAFT_POSITIONAL.flatMap((row) => DRAFT_SERIES.map((series) => Number(row[series.key]) || 0))
+  );
+  const DRAFT_CHART_NICE_MAX = Math.max(10, Math.ceil(Math.max(DRAFT_OVERALL_MAX, DRAFT_POSITIONAL_MAX) / 10) * 10);
+
   const SERIES_CONFIG = [
     { key: 'QB %', label: 'QB %', color: colors.qb },
     { key: 'RB %', label: 'RB %', color: colors.rb },
@@ -280,7 +286,13 @@
             el.dataset[dKey] = dValue;
           });
         } else if (key === 'style' && typeof value === 'object') {
-          Object.assign(el.style, value);
+          Object.entries(value).forEach(([styleKey, styleValue]) => {
+            if (styleKey.startsWith('--')) {
+              el.style.setProperty(styleKey, styleValue);
+            } else {
+              el.style[styleKey] = styleValue;
+            }
+          });
         } else if (key in el) {
           try {
             el[key] = value;
@@ -1044,8 +1056,7 @@
     svg.appendChild(g);
 
     const groupWidth = chartWidth / DRAFT_OVERALL.length;
-    const maxValue = Math.max(...DRAFT_OVERALL.map((row) => row.hit));
-    const niceMax = Math.ceil(maxValue / 10) * 10;
+    const niceMax = DRAFT_CHART_NICE_MAX || 10;
 
     const ticks = [];
     for (let value = 0; value <= niceMax + 0.0001; value += 10) {
@@ -1166,16 +1177,23 @@
         createEl('span', { class: 'legend-label' }, series.key)
       ));
     });
-    container.appendChild(legend);
+
+    const legendHost = document.getElementById('draft-positional-legend');
+    if (legendHost) {
+      legendHost.innerHTML = '';
+      legendHost.appendChild(legend);
+    } else {
+      container.appendChild(legend);
+    }
 
     const containerWidth = container.clientWidth || 0;
     const fallbackWidth = 360;
     const width = containerWidth > 0 ? containerWidth : fallbackWidth;
-    const height = width < 540 ? 300 : 360;
-    const isCompact = width < 560;
-    const margin = width < 540
-      ? { top: 52, right: 20, bottom: 48, left: 54 }
-      : { top: 52, right: 28, bottom: 56, left: 68 };
+    const isCompact = width < 520;
+    const height = isCompact ? 300 : 320;
+    const margin = isCompact
+      ? { top: 48, right: 20, bottom: 56, left: 54 }
+      : { top: 32, right: 24, bottom: 56, left: 60 };
     const chartWidth = width - margin.left - margin.right;
     const chartHeight = height - margin.top - margin.bottom;
     const svg = createSVG('svg', {
@@ -1189,10 +1207,14 @@
 
     const rounds = DRAFT_POSITIONAL.map((row) => row.rd);
     const stepX = chartWidth / (rounds.length - 1 || 1);
-    const yTicks = [0, 20, 40, 60, 80, 100];
+    const niceMax = DRAFT_CHART_NICE_MAX || 10;
+    const yTicks = [];
+    for (let value = 0; value <= niceMax + 0.0001; value += 10) {
+      yTicks.push(value);
+    }
 
     yTicks.forEach((tick) => {
-      const y = chartHeight - (tick / 100) * chartHeight;
+      const y = chartHeight - (tick / niceMax) * chartHeight;
       g.appendChild(createSVG('line', {
         x1: 0,
         x2: chartWidth,
@@ -1213,7 +1235,7 @@
       const x = index * stepX;
       g.appendChild(createSVG('text', {
         x,
-        y: chartHeight + 28,
+        y: chartHeight + 26,
         fill: colors.subtext,
         'font-size': '12',
         'text-anchor': 'middle'
@@ -1225,7 +1247,7 @@
     DRAFT_SERIES.forEach((series) => {
       const points = DRAFT_POSITIONAL.map((row, index) => ({
         x: index * stepX,
-        y: chartHeight - (row[series.key] / 100) * chartHeight,
+        y: chartHeight - ((Number(row[series.key]) || 0) / niceMax) * chartHeight,
         value: row[series.key],
         roundIndex: index
       }));
@@ -1259,6 +1281,14 @@
       stroke: 'rgba(255,255,255,0.18)'
     }));
 
+    g.appendChild(createSVG('text', {
+      x: chartWidth / 2,
+      y: chartHeight + 42,
+      fill: colors.subtext,
+      'font-size': '12',
+      'text-anchor': 'middle'
+    }, document.createTextNode('Draft Round')));
+
     container.appendChild(svg);
 
     const chipsContainer = createEl('div', {
@@ -1287,19 +1317,34 @@
         .sort((a, b) => b.value - a.value);
 
       sortedSeries.forEach((entry) => {
+        const chipChildren = [];
+
+        if (isCompact) {
+          chipChildren.push(createEl('span', {
+            class: 'draft-round-chip-value',
+            style: { color: entry.color }
+          }, `${entry.value}%`));
+        } else {
+          chipChildren.push(
+            createEl('span', {
+              class: 'draft-round-chip-dot',
+              style: { backgroundColor: entry.color }
+            })
+          );
+          chipChildren.push(createEl('span', { class: 'draft-round-chip-pos' }, entry.key));
+          chipChildren.push(createEl('span', {
+            class: 'draft-round-chip-value',
+            style: { color: entry.color }
+          }, `${entry.value}%`));
+        }
+
         const chip = createEl('div', {
-          class: 'draft-round-chip',
+          class: `draft-round-chip${isCompact ? ' draft-round-chip--compact' : ''}`,
           style: {
             '--chip-accent': entry.color,
-            borderColor: hexToRgba(entry.color, 0.55)
+            borderColor: hexToRgba(entry.color, isCompact ? 0.35 : 0.55)
           }
-        },
-        createEl('span', {
-          class: 'draft-round-chip-dot',
-          style: { backgroundColor: entry.color }
-        }),
-        createEl('span', { class: 'draft-round-chip-pos' }, entry.key),
-        createEl('span', { class: 'draft-round-chip-value' }, `${entry.value}%`));
+        }, ...chipChildren);
 
         column.appendChild(chip);
       });

--- a/DHP2_DeployDraft1.51/styles/styles.css
+++ b/DHP2_DeployDraft1.51/styles/styles.css
@@ -4771,6 +4771,26 @@ body[data-page="research"] .app-header {
   font-size: 0.86rem;
 }
 
+.syop-panel-subhead {
+  margin: 0.22rem 0 0.55rem;
+  color: rgba(182, 185, 214, 0.78);
+  font-size: 0.86rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.1rem;
+  align-items: center;
+}
+
+.syop-panel-subhead .syop-line-legend {
+  margin: 0;
+  gap: 0.75rem;
+}
+
+.syop-panel-subhead .legend-item {
+  font-size: 0.8rem;
+  color: rgba(226, 231, 255, 0.92);
+}
+
 .syop-draft-hero {
   margin-bottom: 1.35rem;
   gap: 0.9rem 1.45rem;
@@ -5151,6 +5171,7 @@ body[data-page="research"] .app-header {
   display: grid;
   grid-template-columns: repeat(var(--round-count), minmax(0, 1fr));
   gap: 0.55rem;
+  justify-items: center;
 }
 
 .draft-round-chip-col {
@@ -5177,6 +5198,13 @@ body[data-page="research"] .app-header {
   white-space: nowrap;
 }
 
+.draft-round-chip--compact {
+  justify-content: center;
+  padding: 0.2rem 0.45rem;
+  font-size: 0.72rem;
+  text-transform: none;
+}
+
 .draft-round-chip-dot {
   width: 0.45rem;
   height: 0.45rem;
@@ -5193,6 +5221,7 @@ body[data-page="research"] .app-header {
 .draft-round-chip-value {
   color: rgba(232, 235, 255, 0.88);
   font-variant-numeric: tabular-nums;
+  font-weight: 600;
 }
 
 .draft-round-chip-col .draft-round-chip:not(:last-child) {
@@ -5201,7 +5230,7 @@ body[data-page="research"] .app-header {
 
 .draft-round-tiles {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
   gap: 0.6rem;
   margin-top: 0.75rem;
 }
@@ -5227,6 +5256,7 @@ body[data-page="research"] .app-header {
   font-size: 0.85rem;
   background: rgba(9, 11, 24, 0.8);
   border: 1px solid rgba(255, 255, 255, 0.12);
+  flex: 0 0 28px;
 }
 
 .draft-tile-value {


### PR DESCRIPTION
## Summary
- streamline positional round chips by removing redundant labels on compact layouts and color-coding the values while keeping per-round alignment
- tweak chip grid alignment and spacing plus adjust overall round tile sizing to stay readable at narrower widths

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d4b7975e3c832e9813df4abd1ca58b