### PR TITLE
Tighten desktop comparison chip spacing

### DIFF
--- a/DHP2_DeployDraft1/DHP2_DeployDraft1.6/styles/styles.css
+++ b/DHP2_DeployDraft1/DHP2_DeployDraft1.6/styles/styles.css
@@ -3641,6 +3641,55 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
+
+    @media (min-width: 1024px) {
+        .comparison-summary-chips-row {
+            justify-content: space-around;
+        }
+
+        .comparison-summary-chips-row .summary-chips-container,
+        .player-name-header-container {
+            flex: 0 1 clamp(16rem, 23vw, 20rem);
+            width: clamp(16rem, 23vw, 20rem);
+        }
+
+        .player-name-header-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .player-name-header {
+            width: 100%;
+        }
+
+        .comparison-summary-chips-row .summary-chip {
+            width: 100%;
+        }
+
+        .player-name-header .player-vitals--compare {
+            display: flex;
+            width: 100%;
+            justify-content: space-between;
+            gap: 1.75rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .chip-header-value {
+            margin-right: 0.5rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .chip-unit {
+            margin-left: 0.5rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .chip-values {
+            gap: 0.5rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .pos-rank-container {
+            column-gap: 0.4rem;
+        }
+    }
     
     /* · · Table Header · · */
     .player-header h4 {

--- a/DHP2_DeployDraft1/styles/styles.css
+++ b/DHP2_DeployDraft1/styles/styles.css
@@ -3591,6 +3591,55 @@ body[data-page="rosters"] #secondary-header-row #analyzeLeagueButton.active {
         border-top: 1px solid var(--color-panel-border);
         border-bottom: 1px solid var(--color-panel-border);
     }
+
+    @media (min-width: 1024px) {
+        .comparison-summary-chips-row {
+            justify-content: space-around;
+        }
+
+        .comparison-summary-chips-row .summary-chips-container,
+        .player-name-header-container {
+            flex: 0 1 clamp(16rem, 23vw, 20rem);
+            width: clamp(16rem, 23vw, 20rem);
+        }
+
+        .player-name-header-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .player-name-header {
+            width: 100%;
+        }
+
+        .comparison-summary-chips-row .summary-chip {
+            width: 100%;
+        }
+
+        .player-name-header .player-vitals--compare {
+            display: flex;
+            width: 100%;
+            justify-content: space-between;
+            gap: 1.75rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .chip-header-value {
+            margin-right: 0.5rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .chip-unit {
+            margin-left: 0.5rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .chip-values {
+            gap: 0.5rem;
+        }
+
+        .comparison-summary-chips-row .summary-chip .pos-rank-container {
+            column-gap: 0.4rem;
+        }
+    }
     
     /* · · Table Header · · */
     .player-header h4 {


### PR DESCRIPTION
## Summary
- widen the desktop player vitals layout spacing inside the comparison header
- add desktop-only spacing tweaks so chip header values, labels, and ranking rows have more breathing room

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4dc045ee4832e88298adf478d2a8c